### PR TITLE
Quake 2 support improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 build/
 CMakeFiles/
 *.xcodeproj
+3rdparty/embree

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ bin/
 build/
 CMakeFiles/
 *.xcodeproj
-3rdparty/embree

--- a/common/bspfile.cc
+++ b/common/bspfile.cc
@@ -423,8 +423,11 @@ void Q2_SwapBSPFile (q2bsp_t *bsp, qboolean todisk)
     //
     for (i=0 ; i<bsp->numtexinfo ; i++)
     {
-        for (j=0 ; j<8 ; j++)
-            bsp->texinfo[i].vecs[0][j] = LittleFloat (bsp->texinfo[i].vecs[0][j]);
+        for (j=0 ; j<4 ; j++)
+        {
+            bsp->texinfo[i].vecs[0][j] = LittleFloat(bsp->texinfo[i].vecs[0][j]);
+            bsp->texinfo[i].vecs[1][j] = LittleFloat(bsp->texinfo[i].vecs[1][j]);
+        }
         bsp->texinfo[i].flags = LittleLong (bsp->texinfo[i].flags);
         bsp->texinfo[i].value = LittleLong (bsp->texinfo[i].value);
         bsp->texinfo[i].nexttexinfo = LittleLong (bsp->texinfo[i].nexttexinfo);
@@ -2096,6 +2099,7 @@ CopyLump(const dheader_t *header, int lumpnum, void *destptr)
         break;
     default:
         Error("Unsupported BSP version: %d", header->version);
+        throw; //mxd. Fixes "Uninitialized variable" warning
     }
 
     length = header->lumps[lumpnum].filelen;
@@ -2110,12 +2114,12 @@ CopyLump(const dheader_t *header, int lumpnum, void *destptr)
         dmodel_t *out;
         int i, j;
         if (length % sizeof(dmodelq1_t))
-                Error("%s: odd %s lump size", __func__, lumpspec->name);
+            Error("%s: odd %s lump size", __func__, lumpspec->name);
         length /= sizeof(dmodelq1_t);
 
         buffer = *bufferptr = static_cast<byte *>(malloc(length * sizeof(dmodel_t)));
         if (!buffer)
-                Error("%s: allocation of %i bytes failed.", __func__, length);
+            Error("%s: allocation of %i bytes failed.", __func__, length);
         out = (dmodel_t*)buffer;
         for (i = 0; i < length; i++)
         {
@@ -2167,6 +2171,7 @@ Q2_CopyLump(const q2_dheader_t *header, int lumpnum, void *destptr)
             break;
         default:
             Error("Unsupported BSP version: %d", header->version);
+            throw; //mxd. Fixes "Uninitialized variable" warning
     }
     
     length = header->lumps[lumpnum].filelen;
@@ -2496,8 +2501,8 @@ AddLump(bspfile_t *bspfile, int lumpnum, const void *data, int count)
         q2 = true;
         break;
     default:
-        Error("Unsupported BSP version: %d",
-              LittleLong(bspfile->version));
+        Error("Unsupported BSP version: %d", LittleLong(bspfile->version));
+        throw; //mxd. Fixes "Uninitialized variable" warning
     }
 
     byte pad[4] = {0};

--- a/common/bspfile.cc
+++ b/common/bspfile.cc
@@ -1529,6 +1529,7 @@ static void FreeMBSP(mbsp_t *bsp)
     free(bsp->dvisdata);
     free(bsp->dlightdata);
     free(bsp->dtexdata);
+    free(bsp->drgbatexdata); //mxd
     free(bsp->dentdata);
     free(bsp->dleafs);
     free(bsp->dplanes);

--- a/common/cmdlib.cc
+++ b/common/cmdlib.cc
@@ -170,7 +170,7 @@ SetQdirFromPath(const char *basedirname, const char *path)
 
     // Expect mod folder to be above "maps" folder
     path_s = path_s.substr(0, pos);
-    strcpy_s(gamedir, (path_s + PATHSEPERATOR).c_str());
+    strcpy(gamedir, (path_s + PATHSEPERATOR).c_str());
     logprint("gamedir: %s\n", gamedir);
 
     // See if it's the main game data folder (ID1 / baseq2 / data1 etc.)
@@ -186,7 +186,7 @@ SetQdirFromPath(const char *basedirname, const char *path)
             const std::string checkpath_s = path_s + PATHSEPERATOR + basedir_s;
             if (dir_exists(checkpath_s.c_str())) {
                 // Set basedir
-                strcpy_s(basedir, (checkpath_s + PATHSEPERATOR).c_str());
+                strcpy(basedir, (checkpath_s + PATHSEPERATOR).c_str());
                 logprint("basedir: %s\n", basedir);
                 break;
             }
@@ -201,7 +201,7 @@ SetQdirFromPath(const char *basedirname, const char *path)
         // qdir is already in path_s
     } else {
         // Set basedir
-        strcpy_s(basedir, (path_s + PATHSEPERATOR).c_str());
+        strcpy(basedir, (path_s + PATHSEPERATOR).c_str());
         logprint("basedir: %s\n", basedir);
 
         // qdir shound be 1 level above basedir
@@ -210,7 +210,7 @@ SetQdirFromPath(const char *basedirname, const char *path)
     }
 
     // Store qdir...
-    strcpy_s(qdir, (path_s + PATHSEPERATOR).c_str());
+    strcpy(qdir, (path_s + PATHSEPERATOR).c_str());
     logprint("qdir:    %s\n", qdir);
 }
 

--- a/common/mathlib.cc
+++ b/common/mathlib.cc
@@ -89,6 +89,12 @@ VecStr(const vec3_t vec)
     return buf;
 }
 
+const char * //mxd
+VecStr(const qvec3f vec)
+{
+    return VecStr(vec3_t {vec[0], vec[1], vec[2]});
+}
+
 const char *
 VecStrf(const vec3_t vec)
 {
@@ -101,6 +107,12 @@ VecStrf(const vec3_t vec)
              vec[0], vec[1], vec[2]);
 
     return buf;
+}
+
+const char * //mxd
+VecStrf(const qvec3f vec)
+{
+    return VecStrf(vec3_t{ vec[0], vec[1], vec[2] });
 }
 
 void ClearBounds(vec3_t mins, vec3_t maxs)
@@ -376,6 +388,7 @@ NormalizePDF(const std::vector<float> &pdf)
     }
     
     std::vector<float> normalizedPdf;
+    normalizedPdf.reserve(pdf.size()); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html
     for (float val : pdf) {
         normalizedPdf.push_back(val / pdfSum);
     }
@@ -755,6 +768,7 @@ static std::vector<qvec3f> winding_to_glm(const winding_t *w)
     if (w == nullptr)
         return {};
     std::vector<qvec3f> res;
+    res.reserve(w->numpoints); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html
     for (int i=0; i<w->numpoints; i++) {
         res.push_back(vec3_t_to_glm(w->p[i]));
     }

--- a/common/mathlib.cc
+++ b/common/mathlib.cc
@@ -92,7 +92,9 @@ VecStr(const vec3_t vec)
 const char * //mxd
 VecStr(const qvec3f vec)
 {
-    return VecStr(vec3_t {vec[0], vec[1], vec[2]});
+    vec3_t v;
+    glm_to_vec3_t(vec, v);
+    return VecStr(v);
 }
 
 const char *
@@ -112,7 +114,9 @@ VecStrf(const vec3_t vec)
 const char * //mxd
 VecStrf(const qvec3f vec)
 {
-    return VecStrf(vec3_t{ vec[0], vec[1], vec[2] });
+    vec3_t v;
+    glm_to_vec3_t(vec, v);
+    return VecStrf(v);
 }
 
 void ClearBounds(vec3_t mins, vec3_t maxs)
@@ -801,7 +805,7 @@ std::vector<qvec3f> GLM_ShrinkPoly(const std::vector<qvec3f> &poly, const float 
     vector<qvec3f> clipped = poly;
     
     for (const qvec4f &edge : edgeplanes) {
-        const qvec4f shrunkEdgePlane(edge[0], edge[1], edge[2], edge[3] + 1);
+        const qvec4f shrunkEdgePlane(edge[0], edge[1], edge[2], edge[3] + amount);
         clipped = GLM_ClipPoly(clipped, shrunkEdgePlane).first;
     }
     

--- a/common/mesh.cc
+++ b/common/mesh.cc
@@ -33,8 +33,9 @@ using namespace std;
 // FIXME: Remove
 std::vector<qvec3f> qvecsToGlm(std::vector<qvec3f> qvecs) {
     std::vector<qvec3f> res;
+    res.reserve(qvecs.size()); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html
     for (const auto &qvec : qvecs) {
-        res.push_back(qvec3f(qvec[0], qvec[1], qvec[2]));
+        res.emplace_back(qvec[0], qvec[1], qvec[2]); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     }
     return res;
 }
@@ -98,9 +99,9 @@ mesh_t buildMeshFromBSP(const mbsp_t *bsp)
     mesh_t res;
     for (int i=0; i<bsp->numvertexes; i++) {
         const dvertex_t *vert = &bsp->dvertexes[i];
-        res.verts.push_back(qvec3f(vert->point[0],
-                                   vert->point[1],
-                                   vert->point[2]));
+        res.verts.emplace_back(vert->point[0],
+                               vert->point[1],
+                               vert->point[2]); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     }
     
     for (int i=0; i<bsp->numfaces; i++) {
@@ -159,7 +160,7 @@ static octree_t<vertnum_t> build_vert_octree(const mesh_t &mesh)
         const qvec3f vert = mesh.verts[i];
         const aabb3f bbox(vert, vert);
         
-        vertBboxNumPairs.push_back(make_pair(bbox, i));
+        vertBboxNumPairs.emplace_back(bbox, i); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     }
 
     return makeOctree(vertBboxNumPairs);

--- a/common/polylib.cc
+++ b/common/polylib.cc
@@ -556,6 +556,7 @@ polylib::PointInWindingEdges(const winding_edges_t *wi, const vec3_t point)
 std::vector<qvec3f> polylib::GLM_WindingPoints(const winding_t *w)
 {
     std::vector<qvec3f> points;
+    points.reserve(w->numpoints); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html
     for (int j = 0; j < w->numpoints; j++) {
         points.push_back(vec3_t_to_glm(w->p[j]));
     }

--- a/include/common/bspfile.hh
+++ b/include/common/bspfile.hh
@@ -172,6 +172,13 @@ typedef struct miptex_s {
     uint32_t offsets[MIPLEVELS];        /* four mip maps stored */
 } miptex_t;
 
+//mxd. Used to store RGBA data in mbsp->drgbatexdata
+typedef struct {
+    char name[32]; // Same as in Q2
+    unsigned width, height;
+    unsigned offset; // Offset to RGBA texture pixels
+} rgba_miptex_t;
+
 typedef struct {
     float point[3];
 } dvertex_t;
@@ -212,37 +219,39 @@ typedef struct {
 // these definitions also need to be in q_shared.h!
 
 // lower bits are stronger, and will eat weaker brushes completely
-#define    Q2_CONTENTS_SOLID            1        // an eye is never valid in a solid
-#define    Q2_CONTENTS_WINDOW            2        // translucent, but not watery
-#define    Q2_CONTENTS_AUX            4
+#define    Q2_CONTENTS_SOLID           1        // an eye is never valid in a solid
+#define    Q2_CONTENTS_WINDOW          2        // translucent, but not watery
+#define    Q2_CONTENTS_AUX             4
 #define    Q2_CONTENTS_LAVA            8
-#define    Q2_CONTENTS_SLIME            16
-#define    Q2_CONTENTS_WATER            32
+#define    Q2_CONTENTS_SLIME           16
+#define    Q2_CONTENTS_WATER           32
 #define    Q2_CONTENTS_MIST            64
 #define    Q2_LAST_VISIBLE_CONTENTS    64
 
+#define    Q2_CONTENTS_LIQUID   (Q2_CONTENTS_LAVA|Q2_CONTENTS_SLIME|Q2_CONTENTS_WATER) //mxd
+
 // remaining contents are non-visible, and don't eat brushes
 
-#define    Q2_CONTENTS_AREAPORTAL        0x8000
+#define    Q2_CONTENTS_AREAPORTAL     0x8000
 
-#define    Q2_CONTENTS_PLAYERCLIP        0x10000
+#define    Q2_CONTENTS_PLAYERCLIP     0x10000
 #define    Q2_CONTENTS_MONSTERCLIP    0x20000
 
 // currents can be added to any other contents, and may be mixed
-#define    Q2_CONTENTS_CURRENT_0        0x40000
-#define    Q2_CONTENTS_CURRENT_90        0x80000
+#define    Q2_CONTENTS_CURRENT_0      0x40000
+#define    Q2_CONTENTS_CURRENT_90     0x80000
 #define    Q2_CONTENTS_CURRENT_180    0x100000
 #define    Q2_CONTENTS_CURRENT_270    0x200000
-#define    Q2_CONTENTS_CURRENT_UP        0x400000
-#define    Q2_CONTENTS_CURRENT_DOWN    0x800000
+#define    Q2_CONTENTS_CURRENT_UP     0x400000
+#define    Q2_CONTENTS_CURRENT_DOWN   0x800000
 
-#define    Q2_CONTENTS_ORIGIN            0x1000000    // removed before bsping an entity
+#define    Q2_CONTENTS_ORIGIN         0x1000000    // removed before bsping an entity
 
 #define    Q2_CONTENTS_MONSTER        0x2000000    // should never be on a brush, only in game
 #define    Q2_CONTENTS_DEADMONSTER    0x4000000
-#define    Q2_CONTENTS_DETAIL            0x8000000    // brushes to be added after vis leafs
+#define    Q2_CONTENTS_DETAIL         0x8000000    // brushes to be added after vis leafs
 #define    Q2_CONTENTS_TRANSLUCENT    0x10000000    // auto set if any surface has trans
-#define    Q2_CONTENTS_LADDER            0x20000000
+#define    Q2_CONTENTS_LADDER         0x20000000
 
 typedef struct {
     int32_t planenum;
@@ -356,6 +365,8 @@ typedef struct {
 
 #define    Q2_SURF_HINT       0x100    // make a primary bsp splitter
 #define    Q2_SURF_SKIP       0x200    // completely ignore, allowing non-closed brushes
+
+#define    Q2_SURF_TRANSLUCENT (Q2_SURF_TRANS33|Q2_SURF_TRANS66) //mxd
 
 /*
  * Note that edge 0 is never used, because negative edge nums are used for
@@ -739,6 +750,9 @@ typedef struct {
     
     int texdatasize;
     dmiptexlump_t *dtexdata;
+
+    int rgbatexdatasize; //mxd
+    dmiptexlump_t *drgbatexdata; //mxd. Followed by rgba_miptex_t structs
     
     int entdatasize;
     char *dentdata;
@@ -818,9 +832,9 @@ typedef struct {
     bspxentry_t *bspxentries;
 } bspdata_t;
 
-void LoadBSPFile(char *filename, bspdata_t *bsp);       //returns the filename as contained inside a bsp
-void WriteBSPFile(const char *filename, bspdata_t *bsp);
-void PrintBSPFileSizes(const bspdata_t *bsp);
+void LoadBSPFile(char *filename, bspdata_t *bspdata);       //returns the filename as contained inside a bsp
+void WriteBSPFile(const char *filename, bspdata_t *bspdata);
+void PrintBSPFileSizes(const bspdata_t *bspdata);
 void ConvertBSPFormat(int32_t version, bspdata_t *bspdata);
 void BSPX_AddLump(bspdata_t *bspdata, const char *xname, const void *xdata, size_t xsize);
 const void *BSPX_GetLump(bspdata_t *bspdata, const char *xname, size_t *xsize);

--- a/include/common/bsputils.hh
+++ b/include/common/bsputils.hh
@@ -37,6 +37,7 @@ bsp2_dface_t *BSP_GetFace(mbsp_t *bsp, int fnum);
 
 int Face_VertexAtIndex(const mbsp_t *bsp, const bsp2_dface_t *f, int v);
 void Face_PointAtIndex(const mbsp_t *bsp, const bsp2_dface_t *f, int v, vec3_t point_out);
+void Face_Normal(const mbsp_t *bsp, const bsp2_dface_t *f, vec3_t norm); //mxd
 plane_t Face_Plane(const mbsp_t *bsp, const bsp2_dface_t *f);
 const gtexinfo_t *Face_Texinfo(const mbsp_t *bsp, const bsp2_dface_t *face);
 const rgba_miptex_t *Face_Miptex(const mbsp_t *bsp, const bsp2_dface_t *face); //mxd. miptex_t -> rgba_miptex_t

--- a/include/common/bsputils.hh
+++ b/include/common/bsputils.hh
@@ -39,12 +39,14 @@ int Face_VertexAtIndex(const mbsp_t *bsp, const bsp2_dface_t *f, int v);
 void Face_PointAtIndex(const mbsp_t *bsp, const bsp2_dface_t *f, int v, vec3_t point_out);
 plane_t Face_Plane(const mbsp_t *bsp, const bsp2_dface_t *f);
 const gtexinfo_t *Face_Texinfo(const mbsp_t *bsp, const bsp2_dface_t *face);
-const miptex_t *Face_Miptex(const mbsp_t *bsp, const bsp2_dface_t *face);
+const rgba_miptex_t *Face_Miptex(const mbsp_t *bsp, const bsp2_dface_t *face); //mxd. miptex_t -> rgba_miptex_t
 const char *Face_TextureName(const mbsp_t *bsp, const bsp2_dface_t *face);
 bool Face_IsLightmapped(const mbsp_t *bsp, const bsp2_dface_t *face);
 const float *GetSurfaceVertexPoint(const mbsp_t *bsp, const bsp2_dface_t *f, int v);
-int TextureName_Contents(const char *texname);
-int Face_Contents(const mbsp_t *bsp, const bsp2_dface_t *face);
+//int TextureName_Contents(const char *texname); //mxd
+bool Contents_IsTranslucent(const mbsp_t *bsp, int contents); //mxd
+bool Face_IsTranslucent(const mbsp_t *bsp, const bsp2_dface_t *face); //mxd
+int Face_Contents(const mbsp_t *bsp, const bsp2_dface_t *face); //mxd. Returns CONTENTS_ value for Q1, Q2_SURF_ bitflags for Q2...
 const dmodel_t *BSP_DModelForModelString(const mbsp_t *bsp, const std::string &submodel_str);
 vec_t Plane_Dist(const vec3_t point, const dplane_t *plane);
 bool Light_PointInSolid(const mbsp_t *bsp, const dmodel_t *model, const vec3_t point);

--- a/include/common/cmdlib.hh
+++ b/include/common/cmdlib.hh
@@ -57,8 +57,8 @@ typedef unsigned char byte;
 extern int myargc;
 extern char **myargv;
 
-char *Q_strupr(char *in);
-char *Q_strlower(char *in);
+char *Q_strupr(char * start);
+char *Q_strlower(char * start);
 int Q_strncasecmp(const char *s1, const char *s2, int n);
 int Q_strcasecmp(const char *s1, const char *s2);
 void Q_getwd(char *out);
@@ -70,8 +70,11 @@ void Q_mkdir(const char *path);
 
 extern char qdir[1024];
 extern char gamedir[1024];
+extern char basedir[1024]; //mxd
 
-void SetQdirFromPath(char *path);
+bool string_iequals(const std::string& a, const std::string& b); //mxd
+
+void SetQdirFromPath(const char *basedirname, const char *path); //mxd
 char *ExpandPath(char *path);
 char *ExpandPathAndArchive(char *path);
 

--- a/include/common/mathlib.hh
+++ b/include/common/mathlib.hh
@@ -248,6 +248,8 @@ bool SetPlanePts(const vec3_t planepts[3], vec3_t normal, vec_t *dist);
 //FIXME: change from static buffers to returning std::string for thread safety
 const char *VecStr(const vec3_t vec);
 const char *VecStrf(const vec3_t vec);
+const char *VecStr(const qvec3f vec); //mxd
+const char *VecStrf(const qvec3f vec); //mxd
 
 // Maps uniform random variables U and V in [0, 1] to uniformly distributed points on a sphere
 void UniformPointOnSphere(vec3_t dir, float u, float v);

--- a/include/common/octree.hh
+++ b/include/common/octree.hh
@@ -174,6 +174,7 @@ public:
         queryTouchingBBox(0, query, res);
         
         std::vector<T> res_vec;
+        res_vec.reserve(res.size()); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html
         for (const auto &item : res) {
             res_vec.push_back(item);
         }

--- a/include/common/polylib.hh
+++ b/include/common/polylib.hh
@@ -19,7 +19,7 @@ typedef struct {
 } winding_edges_t;
     
 #define MAX_POINTS_ON_WINDING 64
-#define ON_EPSILON 0.1
+#define ON_EPSILON 0.1f //mxd. Changed from 0.1 to silence compiler warning
 
 winding_t *AllocWinding(int points);
 vec_t WindingArea(const winding_t * w);

--- a/include/light/bounce.hh
+++ b/include/light/bounce.hh
@@ -49,7 +49,6 @@ const std::vector<bouncelight_t> &BounceLights();
 const std::vector<int> &BounceLightsForFaceNum(int facenum);
 void MakeTextureColors (const mbsp_t *bsp);
 void MakeBounceLights (const globalconfig_t &cfg, const mbsp_t *bsp);
-/** Returns color components in [0, 255] */
-qvec3f Palette_GetColor(int i);
+void Face_LookupTextureColor (const mbsp_t *bsp, const bsp2_dface_t *face, vec3_t color); //mxd
 
-#endif /* __LIGHT_BOUNCe_H__ */
+#endif /* __LIGHT_BOUNCE_H__ */

--- a/include/light/entities.hh
+++ b/include/light/entities.hh
@@ -58,7 +58,7 @@ public:
     vec3_t spotvec; // computed
     float spotfalloff;
     float spotfalloff2;
-    miptex_t *projectedmip; /*projected texture*/
+    rgba_miptex_t *projectedmip; /*projected texture*/ //mxd. miptex_t -> rgba_miptex_t
     float projectionmatrix[16]; /*matrix used to project the specified texture. already contains origin.*/
 
     const entdict_t *epairs;
@@ -188,5 +188,7 @@ bool EntDict_CheckNoEmptyValues(const mbsp_t *bsp, const entdict_t &entdict);
 bool EntDict_CheckTargetKeysMatched(const mbsp_t *bsp, const entdict_t &entity, const std::vector<entdict_t> &all_edicts);
 
 bool EntDict_CheckTargetnameKeyMatched(const mbsp_t *bsp, const entdict_t &entity, const std::vector<entdict_t> &all_edicts);
+
+std::vector<entdict_t> EntData_Parse(const char *entdata); //mxd
 
 #endif /* __LIGHT_ENTITIES_H__ */

--- a/include/light/imglib.hh
+++ b/include/light/imglib.hh
@@ -1,0 +1,62 @@
+/*  Copyright (C) 1996-1997  Id Software, Inc.
+Copyright (C) 2017 Eric Wasylishen
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See file, 'COPYING', for details.
+*/
+
+#ifndef __COMMON_IMGLIB_H__
+#define __COMMON_IMGLIB_H__
+
+#include <common/cmdlib.hh>
+#include <common/bspfile.hh>
+
+typedef struct {
+    char name[32];
+    unsigned width, height;
+    unsigned offsets[MIPLEVELS]; // four mip maps stored
+    char animname[32]; // next frame in animation chain
+    int flags;
+    int contents;
+    int value;
+} q2_miptex_t;
+
+typedef struct {
+    byte r;
+    byte g;
+    byte b;
+    byte a;
+} color_rgba;
+
+//mxd. Moved from ltface.cc
+extern byte thepalette[768];
+
+// Palette
+void LoadPalette(bspdata_t *bspdata);
+// Returns color components in [0, 255]
+qvec3f Palette_GetColor(const int i);
+//mxd. Returns RGBA color components in [0, 255]
+qvec4f Texture_GetColor(const rgba_miptex_t *tex, const int i);
+
+// Image loading
+qboolean LoadPCX(const char *filename, byte **pixels, byte **palette, int *width, int *height);
+qboolean LoadTGA(const char *filename, byte **pixels, int *width, int *height);
+qboolean LoadWAL(const char *filename, byte **pixels, int *width, int *height);
+
+// Texture loading
+void LoadOrConvertTextures(mbsp_t *bsp); // Loads textures from disk and stores them in bsp->drgbatexdata (Quake 2) / Converts paletted bsp->dtexdata textures to RGBA bsp->drgbatexdata textures (Quake / Hexen2)
+
+#endif

--- a/include/light/light.hh
+++ b/include/light/light.hh
@@ -281,8 +281,12 @@ public:
     lockable_bool_t bouncestyled;
     lockable_vec_t bouncescale, bouncecolorscale;
     
-    /* sunlight */
+    /* Q2 surface lights (mxd) */
+    lockable_vec_t surflightscale;
+    lockable_vec_t surflightbouncescale;
+    lockable_vec_t surflightsubdivision;
     
+    /* sunlight */
     lockable_vec_t sunlight;
     lockable_vec3_t sunlight_color;
     lockable_vec_t sun2;
@@ -326,20 +330,25 @@ public:
         bouncescale {"bouncescale", 1.0f, 0.0f, 100.0f},
         bouncecolorscale {"bouncecolorscale", 0.0f, 0.0f, 1.0f},
 
+        /* Q2 surface lights (mxd) */
+        surflightscale       { "surflightscale", 0.3f }, // Strange defaults to match arghrad3 look...
+        surflightbouncescale { "surflightbouncescale", 0.1f },
+        surflightsubdivision { strings { "surflightsubdivision", "choplight" }, 16.0f, 1.0f, 8192.0f }, // "choplight" - arghrad3 name
+
         /* sun */
-        sunlight         { "sunlight", 0.0f },                   /* main sun */
+        sunlight        { "sunlight", 0.0f },  /* main sun */
         sunlight_color  { "sunlight_color", 255.0f, 255.0f, 255.0f, vec3_transformer_t::NORMALIZE_COLOR_TO_255 },
-        sun2             { "sun2", 0.0f },                   /* second sun */
+        sun2            { "sun2", 0.0f },      /* second sun */
         sun2_color      { "sun2_color", 255.0f, 255.0f, 255.0f, vec3_transformer_t::NORMALIZE_COLOR_TO_255 },
-        sunlight2        { "sunlight2", 0.0f },                   /* top sky dome */
+        sunlight2       { "sunlight2", 0.0f }, /* top sky dome */
         sunlight2_color { strings{"sunlight2_color", "sunlight_color2"}, 255.0f, 255.0f, 255.0f, vec3_transformer_t::NORMALIZE_COLOR_TO_255 },
-        sunlight3        { "sunlight3", 0.0f },                   /* bottom sky dome */
+        sunlight3       { "sunlight3", 0.0f }, /* bottom sky dome */
         sunlight3_color { strings{"sunlight3_color", "sunlight_color3"}, 255.0f, 255.0f, 255.0f, vec3_transformer_t::NORMALIZE_COLOR_TO_255 },
-        sunlight_dirt    { "sunlight_dirt", 0.0f },
-        sunlight2_dirt   { "sunlight2_dirt", 0.0f },
+        sunlight_dirt   { "sunlight_dirt", 0.0f },
+        sunlight2_dirt  { "sunlight2_dirt", 0.0f },
         sunvec          { strings{"sunlight_mangle", "sun_mangle"}, 0.0f, -90.0f, 0.0f, vec3_transformer_t::MANGLE_TO_VEC },  /* defaults to straight down */
         sun2vec         { "sun2_mangle", 0.0f, -90.0f, 0.0f, vec3_transformer_t::MANGLE_TO_VEC },  /* defaults to straight down */
-        sun_deviance     { "sunlight_penumbra", 0.0f, 0.0f, 180.0f }
+        sun_deviance    { "sunlight_penumbra", 0.0f, 0.0f, 180.0f }
     {}
     
     settingsdict_t settings() {
@@ -354,6 +363,7 @@ public:
             &minlightDirt,
             &phongallowed,
             &bounce, &bouncestyled, &bouncescale, &bouncecolorscale,
+            &surflightscale, &surflightbouncescale, &surflightsubdivision, //mxd
             &sunlight,
             &sunlight_color,
             &sun2,
@@ -401,7 +411,7 @@ void FixupGlobalSettings(void);
 void GetFileSpace(byte **lightdata, byte **colordata, byte **deluxdata, int size);
 const modelinfo_t *ModelInfoForModel(const mbsp_t *bsp, int modelnum);
 const modelinfo_t *ModelInfoForFace(const mbsp_t *bsp, int facenum);
-bool Leaf_HasSky(const mbsp_t *bsp, const mleaf_t *leaf);
+//bool Leaf_HasSky(const mbsp_t *bsp, const mleaf_t *leaf); //mxd. Missing definition
 int light_main(int argc, const char **argv);
 
 #endif /* __LIGHT_LIGHT_H__ */

--- a/include/light/light.hh
+++ b/include/light/light.hh
@@ -41,9 +41,9 @@
 
 #include <common/qvec.hh>
 
-#define ON_EPSILON    0.1
-#define ANGLE_EPSILON 0.001
-#define EQUAL_EPSILON 0.001
+#define ON_EPSILON    0.1f
+#define ANGLE_EPSILON 0.001f
+#define EQUAL_EPSILON 0.001f
 
 typedef struct {
     vec3_t color;
@@ -166,8 +166,6 @@ typedef enum {
 extern debugmode_t debugmode;
 extern bool verbose_log;
 
-extern byte thepalette[768];
-    
 /* tracelist is a std::vector of pointers to modelinfo_t to use for LOS tests */
 extern std::vector<const modelinfo_t *> tracelist;
 extern std::vector<const modelinfo_t *> selfshadowlist;
@@ -191,6 +189,8 @@ extern bool dump_face;
 
 extern int dump_vertnum;
 extern bool dump_vert;
+
+extern bool arghradcompat; //mxd
 
 class modelinfo_t {
     using strings = std::vector<std::string>;

--- a/include/light/ltface.hh
+++ b/include/light/ltface.hh
@@ -42,6 +42,7 @@
 
 extern std::atomic<uint32_t> total_light_rays, total_light_ray_hits, total_samplepoints;
 extern std::atomic<uint32_t> total_bounce_rays, total_bounce_ray_hits;
+extern std::atomic<uint32_t> total_surflight_rays, total_surflight_ray_hits; //mxd
 extern std::atomic<uint32_t> fully_transparent_lightmaps;
 
 class faceextents_t {

--- a/include/light/settings.hh
+++ b/include/light/settings.hh
@@ -179,7 +179,13 @@ public:
     }
     
     virtual std::string stringValue() const {
-        return std::to_string(_value);
+        //return std::to_string(_value);
+        
+        //mxd. 1.330000 -> 1.33
+        std::string str = std::to_string(_value);
+        const auto lastnonzero = str.find_last_not_of('0');
+        str.erase(lastnonzero + (lastnonzero == str.find('.') ? 0 : 1), std::string::npos);
+        return str;
     }
     
     lockable_vec_t(std::vector<std::string> names, float v,

--- a/include/light/settings.hh
+++ b/include/light/settings.hh
@@ -77,6 +77,7 @@ public:
             case setting_source_t::DEFAULT: return "default";
             case setting_source_t::MAP: return "map";
             case setting_source_t::COMMANDLINE: return "commandline";
+            default: Error("Error: unknown setting source"); throw; //mxd. Silences compiler warning
         }
     }
 };
@@ -169,7 +170,7 @@ public:
         float f = 0.0f;
         try {
             f = std::stof(str);
-        } catch (std::exception &e) {
+        } catch (std::exception &) {
             logprint("WARNING: couldn't parse '%s' as number for key '%s'\n",
                      str.c_str(), primaryName().c_str());
         }

--- a/include/light/surflight.hh
+++ b/include/light/surflight.hh
@@ -1,0 +1,46 @@
+/*  Copyright (C) 1996-1997  Id Software, Inc.
+Copyright (C) 2018 MaxED
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See file, 'COPYING', for details.
+*/
+
+#ifndef __SURFACE_LIGHT_H__
+#define __SURFACE_LIGHT_H__
+
+#include <vector>
+
+typedef struct {
+    std::vector<qvec3f> poly;
+    std::vector<qvec4f> poly_edgeplanes;
+    qvec3f pos;
+    qvec3f surfnormal;
+    float areascaler;
+
+    // Surface light settings...
+    float value;  // Surface light strength
+    vec3_t color; // Surface color, in [0..1] range
+
+    // Estimated visible AABB culling
+    vec3_t mins;
+    vec3_t maxs;
+} surfacelight_t;
+
+const std::vector<surfacelight_t> &SurfaceLights();
+const std::vector<int> &SurfaceLightsForFaceNum(int facenum);
+void MakeSurfaceLights (const globalconfig_t &cfg, const mbsp_t *bsp);
+
+#endif /* __SURFACE_LIGHT_H__ */

--- a/include/light/surflight.hh
+++ b/include/light/surflight.hh
@@ -24,15 +24,14 @@ See file, 'COPYING', for details.
 #include <vector>
 
 typedef struct {
-    std::vector<qvec3f> poly;
-    std::vector<qvec4f> poly_edgeplanes;
-    qvec3f pos;
+    vec3_t pos;
     qvec3f surfnormal;
-    float areascaler;
+    std::vector<qvec3f> points;
 
     // Surface light settings...
-    float value;  // Surface light strength
-    vec3_t color; // Surface color, in [0..1] range
+    float intensity;       // Surface light strength for each point
+    float totalintensity;  // Total surface light strength
+    vec3_t color;          // Surface color
 
     // Estimated visible AABB culling
     vec3_t mins;
@@ -40,6 +39,7 @@ typedef struct {
 } surfacelight_t;
 
 const std::vector<surfacelight_t> &SurfaceLights();
+int TotalSurfacelightPoints();
 const std::vector<int> &SurfaceLightsForFaceNum(int facenum);
 void MakeSurfaceLights (const globalconfig_t &cfg, const mbsp_t *bsp);
 

--- a/include/light/trace.hh
+++ b/include/light/trace.hh
@@ -20,6 +20,8 @@
 #ifndef __LIGHT_TRACE_H__
 #define __LIGHT_TRACE_H__
 
+#include <light/imglib.hh> //mxd
+
 #include <common/cmdlib.hh>
 #include <common/mathlib.hh>
 #include <common/bspfile.hh>
@@ -42,7 +44,7 @@ enum class hittype_t : uint8_t {
 
 const mleaf_t *Light_PointInLeaf( const mbsp_t *bsp, const vec3_t point );
 int Light_PointContents( const mbsp_t *bsp, const vec3_t point );
-int SampleTexture(const bsp2_dface_t *face, const mbsp_t *bsp, const vec3_t point);
+color_rgba SampleTexture(const bsp2_dface_t *face, const mbsp_t *bsp, const vec3_t point); //mxd. Palette index -> RGBA
 
 class modelinfo_t;
 

--- a/light/CMakeLists.txt
+++ b/light/CMakeLists.txt
@@ -2,10 +2,12 @@ cmake_minimum_required (VERSION 2.8)
 project (light CXX)
 
 set(LIGHT_INCLUDES
+	${CMAKE_SOURCE_DIR}/include/light/imglib.hh
 	${CMAKE_SOURCE_DIR}/include/light/entities.hh
 	${CMAKE_SOURCE_DIR}/include/light/light.hh
 	${CMAKE_SOURCE_DIR}/include/light/phong.hh
 	${CMAKE_SOURCE_DIR}/include/light/bounce.hh
+	${CMAKE_SOURCE_DIR}/include/light/surflight.hh
 	${CMAKE_SOURCE_DIR}/include/light/ltface.hh
 	${CMAKE_SOURCE_DIR}/include/light/trace.hh
 	${CMAKE_SOURCE_DIR}/include/light/litfile.hh
@@ -19,7 +21,9 @@ set(LIGHT_SOURCES
 	light.cc
 	phong.cc
 	bounce.cc
+	surflight.cc
 	settings.cc
+	imglib.cc
 	${CMAKE_SOURCE_DIR}/common/bspfile.cc	
 	${CMAKE_SOURCE_DIR}/common/cmdlib.cc
 	${CMAKE_SOURCE_DIR}/common/mathlib.cc

--- a/light/entities.cc
+++ b/light/entities.cc
@@ -295,7 +295,7 @@ static void
 SetupSpotlights(const globalconfig_t &cfg)
 {
     for (light_t &entity : all_lights) {
-        float targetdist; //mxd
+        float targetdist = 0.0f; //mxd
         if (entity.targetent) {
             vec3_t targetOrigin;
             EntDict_VectorForKey(*entity.targetent, "origin", targetOrigin);
@@ -305,19 +305,17 @@ SetupSpotlights(const globalconfig_t &cfg)
             entity.spotlight = true;
         }
         if (entity.spotlight) {
-            vec_t angle, angle2;
-
-            angle = (entity.spotangle.floatValue() > 0) ? entity.spotangle.floatValue() : 40;
+            const vec_t angle = (entity.spotangle.floatValue() > 0) ? entity.spotangle.floatValue() : 40;
             entity.spotfalloff = -cos(angle / 2 * Q_PI / 180);
 
-            angle2 = entity.spotangle2.floatValue();
+            vec_t angle2 = entity.spotangle2.floatValue();
             if (angle2 <= 0 || angle2 > angle)
                 angle2 = angle;
             entity.spotfalloff2 = -cos(angle2 / 2 * Q_PI / 180);
 
             //mxd. Apply autofalloff?
-            if(entity.falloff.floatValue() == 0 && cfg.spotlightautofalloff.boolValue()) {
-                float coneradius = targetdist * tan(angle / 2 * Q_PI / 180);
+            if(targetdist > 0.0f && entity.falloff.floatValue() == 0 && cfg.spotlightautofalloff.boolValue()) {
+                const float coneradius = targetdist * tan(angle / 2 * Q_PI / 180);
                 entity.falloff.setFloatValue(targetdist + coneradius);
             }
         }

--- a/light/entities.cc
+++ b/light/entities.cc
@@ -105,7 +105,7 @@ LightStyleForTargetname(const std::string &targetname)
     
     // generate a new style number and return it
     const int newStylenum = LIGHT_TARGETS_START + lightstyleForTargetname.size();
-    lightstyleForTargetname.push_back(std::make_pair(targetname, newStylenum));
+    lightstyleForTargetname.emplace_back(targetname, newStylenum); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     
     if (verbose_log) {
         logprint("%s: Allocated lightstyle %d for targetname '%s'\n", __func__, newStylenum, targetname.c_str());
@@ -338,6 +338,13 @@ CheckEntityFields(const globalconfig_t &cfg, light_t *entity)
     //mxd. No negative falloffs pls.
     if(entity->falloff.floatValue() < 0.0f)
         entity->falloff.setFloatValue(0.0f);
+
+    //mxd. Warn about unsupported _falloff / delay combos...
+    if(entity->falloff.floatValue() > 0.0f && entity->getFormula() != LF_LINEAR) {
+        logprint("WARNING: _falloff is currently only supported on linear (delay 0) lights\n"
+            "   %s at (%s)\n", entity->classname(), VecStr(*entity->origin.vec3Value()));
+        entity->falloff.setFloatValue(0.0f);
+    }
 
     if (entity->getFormula() < LF_LINEAR || entity->getFormula() >= LF_COUNT) {
         static qboolean warned_once = true;
@@ -825,7 +832,7 @@ float CalcFov (float fov_x, float width, float height)
     float   x;
 
     if (fov_x < 1 || fov_x > 179)
-        Error ("Bad fov: %f", fov_x);
+        Error ("Unsupported fov: %f. Expected a value in [1..179] range.", fov_x);
 
     x = fov_x/360*Q_PI;
     x = tan(x);
@@ -841,26 +848,26 @@ float CalcFov (float fov_x, float width, float height)
 /*
 finds the texture that is meant to be projected.
 */
-static miptex_t *FindProjectionTexture(const mbsp_t *bsp, const char *texname)
+static rgba_miptex_t *FindProjectionTexture(const mbsp_t *bsp, const char *texname) //mxd. miptex_t -> rgba_miptex_t
 {
-    if (!bsp->texdatasize)
-        return NULL;
+    if (!bsp->rgbatexdatasize)
+        return nullptr;
     
-    dmiptexlump_t *miplump = bsp->dtexdata;
-    miptex_t *miptex;
-    int texnum;
+    dmiptexlump_t *miplump = bsp->drgbatexdata;
+
     /*outer loop finds the textures*/
-    for (texnum = 0; texnum< miplump->nummiptex; texnum++)
+    for (int texnum = 0; texnum < miplump->nummiptex; texnum++)
     {
-        int offset = miplump->dataofs[texnum];
+        const int offset = miplump->dataofs[texnum];
         if (offset < 0)
             continue;
         
-        miptex = (miptex_t*)((byte *)bsp->dtexdata + offset);
+        rgba_miptex_t *miptex = (rgba_miptex_t*)((byte *)bsp->drgbatexdata + offset);
         if (!Q_strcasecmp(miptex->name, texname))
             return miptex;
     }
-    return NULL;
+
+    return nullptr;
 }
 
 /*
@@ -954,24 +961,34 @@ float
 EntDict_FloatForKey(const entdict_t &dict, const std::string key)
 {
     auto s = EntDict_StringForKey(dict, key);
-    if (s == "")
+    if (s.empty())
         return 0;
     
     try {
         return std::stof(s);
-    } catch (std::exception &e) {
+    } catch (std::exception &) {
         return 0.0f;
     }
 }
 
 void
-EntDict_RemoveValueForKey(entdict_t &dict, const std::string key)
+EntDict_RemoveValueForKey(entdict_t &dict, const std::string &key)
 {
-    auto it = dict.find(key);
+    const auto it = dict.find(key);
     if (it != dict.end()) {
         dict.erase(it);
     }
     Q_assert(dict.find(key) == dict.end());
+}
+
+void //mxd
+EntDict_RenameKey(entdict_t &dict, const std::string &from, const std::string &to)
+{
+    const auto it = dict.find(from);
+    if (it != dict.end()) {
+        swap(dict[to], it->second);
+        dict.erase(it);
+    }
 }
 
 static std::string
@@ -1022,8 +1039,8 @@ LoadEntities(const globalconfig_t &cfg, const mbsp_t *bsp)
     for (auto &entdict : entdicts) {
         
         // fix "lightmap_scale"
-        std::string lmscale = EntDict_StringForKey(entdict, "lightmap_scale");
-        if (lmscale != "") {
+        const std::string lmscale = EntDict_StringForKey(entdict, "lightmap_scale");
+        if (!lmscale.empty()) {
             logprint("lightmap_scale should be _lightmap_scale\n");
             
             entdict.erase(entdict.find("lightmap_scale"));
@@ -1033,8 +1050,8 @@ LoadEntities(const globalconfig_t &cfg, const mbsp_t *bsp)
         // setup light styles for switchable lights
         std::string classname = EntDict_StringForKey(entdict, "classname");
         if (classname.find("light") == 0) {
-            std::string targetname = EntDict_StringForKey(entdict, "targetname");
-            if (targetname != "") {
+            const std::string targetname = EntDict_StringForKey(entdict, "targetname");
+            if (!targetname.empty()) {
                 const int style = LightStyleForTargetname(targetname);
                 entdict["style"] = std::to_string(style);
             }
@@ -1042,7 +1059,7 @@ LoadEntities(const globalconfig_t &cfg, const mbsp_t *bsp)
         
         // setup light styles for dynamic shadow entities
         if (EntDict_StringForKey(entdict, "_switchableshadow") == "1") {
-            std::string targetname = EntDict_StringForKey(entdict, "targetname");
+            const std::string targetname = EntDict_StringForKey(entdict, "targetname");
             // if targetname is "", generates a new unique lightstyle
             const int style = LightStyleForTargetname(targetname);
             // TODO: Configurable key?
@@ -1062,18 +1079,35 @@ LoadEntities(const globalconfig_t &cfg, const mbsp_t *bsp)
     /* apply side effects of settings (in particular "dirt") */
     FixupGlobalSettings();
     
-    Q_assert(all_lights.size() == 0);
+    Q_assert(all_lights.empty());
     if (nolights) {
         return;
     }
     
     /* go through all the entities */
-    for (const auto &entdict : entdicts) {
+    for (auto &entdict : entdicts) {
         
         /*
          * Check light entity fields and any global settings in worldspawn.
          */
         if (EntDict_StringForKey(entdict, "classname").find("light") == 0) {
+            //mxd. Convert some Arghrad3 settings...
+            if (arghradcompat) {
+                EntDict_RenameKey(entdict, "_falloff", "delay");     // _falloff -> delay
+                EntDict_RenameKey(entdict, "_distance", "_falloff"); // _distance -> _falloff
+                EntDict_RenameKey(entdict, "_fade", "wait");         // _fade -> wait
+                
+                // _angfade or _angwait -> _anglescale
+                EntDict_RenameKey(entdict, "_angfade", "_anglescale");
+                EntDict_RenameKey(entdict, "_angwait", "_anglescale");
+                const auto anglescale = entdict.find("_anglescale");
+                if(anglescale != entdict.end()) {
+                    // Convert from 0..2 to 0..1 range...
+                    const float val = qmin(1.0f, qmax(0.0f, EntDict_FloatForKey(entdict, "_anglescale") * 0.5f));
+                    entdict["_anglescale"] = std::to_string(val);
+                }
+            }
+            
             /* Allocate a new entity */
             light_t entity {};
             
@@ -1094,11 +1128,21 @@ LoadEntities(const globalconfig_t &cfg, const mbsp_t *bsp)
                 }
             }
             
-            if (entity.project_texture.stringValue() != "") {
+            if (!entity.project_texture.stringValue().empty()) {
                 auto texname = entity.project_texture.stringValue();
                 entity.projectedmip = FindProjectionTexture(bsp, texname.c_str());
-                if (entity.projectedmip == NULL) {
+                if (entity.projectedmip == nullptr) {
                     logprint("WARNING: light has \"_project_texture\" \"%s\", but this texture is not present in the bsp\n", texname.c_str());
+                } 
+                
+                if (!entity.projangle.isChanged()) { //mxd
+                    // Copy from angles
+                    vec3_t angles;
+                    EntDict_VectorForKey(entdict, "angles", angles);
+                    vec3_t mangle{ angles[1], -angles[0], angles[2] }; // -pitch yaw roll -> yaw pitch roll
+                    entity.projangle.setVec3Value(mangle);
+
+                    entity.spotlight = true;
                 }
             }
             
@@ -1268,7 +1312,7 @@ SetupLights(const globalconfig_t &cfg, const mbsp_t *bsp)
     FixLightsOnFaces(bsp);
     EstimateLightVisibility();
     
-    logprint("Final count: %d lights %d suns in use.\n",
+    logprint("Final count: %d lights, %d suns in use.\n",
              static_cast<int>(all_lights.size()),
              static_cast<int>(all_suns.size()));
     
@@ -1279,7 +1323,7 @@ SetupLights(const globalconfig_t &cfg, const mbsp_t *bsp)
 const char *
 ValueForKey(const light_t *ent, const char *key)
 {
-    auto iter = ent->epairs->find(key);
+    const auto iter = ent->epairs->find(key);
     if (iter != ent->epairs->end()) {
         return (*iter).second.c_str();
     } else {
@@ -1547,11 +1591,9 @@ static void GL_SubdivideSurface (const bsp2_dface_t *face, const modelinfo_t *fa
 
 static void MakeSurfaceLights(const mbsp_t *bsp)
 {
-    int i, k;
-
     for (light_t &entity : all_lights) {
         std::string tex = ValueForKey(&entity, "_surface");
-        if (tex != "") {
+        if (!tex.empty()) {
             surfacelight_templates.push_back(entity); // makes a copy
 
             // Hack: clear templates light value to 0 so they don't cast light
@@ -1562,7 +1604,7 @@ static void MakeSurfaceLights(const mbsp_t *bsp)
         }
     }
 
-    if (!surfacelight_templates.size())
+    if (surfacelight_templates.empty())
         return;
 
     if (surflight_dump) {
@@ -1575,27 +1617,22 @@ static void MakeSurfaceLights(const mbsp_t *bsp)
     /* Create the surface lights */
     std::vector<bool> face_visited(static_cast<size_t>(bsp->numfaces), false);
     
-    for (i=0; i<bsp->numleafs; i++) {
+    for (int i = 0; i < bsp->numleafs; i++) {
         const mleaf_t *leaf = bsp->dleafs + i;
-        const bsp2_dface_t *surf;
-        qboolean underwater = leaf->contents != CONTENTS_EMPTY;
+        const qboolean underwater = (bsp->loadversion == Q2_BSPVERSION ? leaf->contents & Q2_CONTENTS_LIQUID : leaf->contents != CONTENTS_EMPTY); //mxd
 
-        for (k = 0; k < leaf->nummarksurfaces; k++) {
-            const modelinfo_t *face_modelinfo;
-            int facenum = bsp->dleaffaces[leaf->firstmarksurface + k];
-
-            surf = BSP_GetFace(bsp, facenum);
-            const char *texname = Face_TextureName(bsp, surf);
-
-            face_modelinfo = ModelInfoForFace(bsp, facenum);
+        for (int k = 0; k < leaf->nummarksurfaces; k++) {
+            const int facenum = bsp->dleaffaces[leaf->firstmarksurface + k];
+            const bsp2_dface_t *surf = BSP_GetFace(bsp, facenum);
+            const modelinfo_t *face_modelinfo = ModelInfoForFace(bsp, facenum);
             
             /* Skip face with no modelinfo */
-            if (face_modelinfo == NULL)
+            if (face_modelinfo == nullptr)
                 continue;
             
             /* Ignore the underwater side of liquid surfaces */
             // FIXME: Use a Face_TextureName function for this
-            if (texname[0] == '*' && underwater)
+            if (/*texname[0] == '*' && */ underwater && Face_IsTranslucent(bsp, surf)) //mxd
                 continue;
 
             /* Skip if already handled */

--- a/light/imglib.cc
+++ b/light/imglib.cc
@@ -1,0 +1,721 @@
+#include <light/imglib.hh>
+#include <light/entities.hh>
+#include <map>
+#include <vector>
+
+
+/*
+============================================================================
+PALETTE
+============================================================================
+*/
+
+byte thepalette[768] = // Quake palette
+{
+    0,0,0,15,15,15,31,31,31,47,47,47,63,63,63,75,75,75,91,91,91,107,107,107,123,123,123,139,139,139,155,155,155,171,171,171,187,187,187,203,203,203,219,219,219,235,235,235,15,11,7,23,15,11,31,23,11,39,27,15,47,35,19,55,43,23,63,47,23,75,55,27,83,59,27,91,67,31,99,75,31,107,83,31,115,87,31,123,95,35,131,103,35,143,111,35,11,11,15,19,19,27,27,27,39,39,39,51,47,47,63,55,55,75,63,63,87,71,71,103,79,79,115,91,91,127,99,99,
+    139,107,107,151,115,115,163,123,123,175,131,131,187,139,139,203,0,0,0,7,7,0,11,11,0,19,19,0,27,27,0,35,35,0,43,43,7,47,47,7,55,55,7,63,63,7,71,71,7,75,75,11,83,83,11,91,91,11,99,99,11,107,107,15,7,0,0,15,0,0,23,0,0,31,0,0,39,0,0,47,0,0,55,0,0,63,0,0,71,0,0,79,0,0,87,0,0,95,0,0,103,0,0,111,0,0,119,0,0,127,0,0,19,19,0,27,27,0,35,35,0,47,43,0,55,47,0,67,
+    55,0,75,59,7,87,67,7,95,71,7,107,75,11,119,83,15,131,87,19,139,91,19,151,95,27,163,99,31,175,103,35,35,19,7,47,23,11,59,31,15,75,35,19,87,43,23,99,47,31,115,55,35,127,59,43,143,67,51,159,79,51,175,99,47,191,119,47,207,143,43,223,171,39,239,203,31,255,243,27,11,7,0,27,19,0,43,35,15,55,43,19,71,51,27,83,55,35,99,63,43,111,71,51,127,83,63,139,95,71,155,107,83,167,123,95,183,135,107,195,147,123,211,163,139,227,179,151,
+    171,139,163,159,127,151,147,115,135,139,103,123,127,91,111,119,83,99,107,75,87,95,63,75,87,55,67,75,47,55,67,39,47,55,31,35,43,23,27,35,19,19,23,11,11,15,7,7,187,115,159,175,107,143,163,95,131,151,87,119,139,79,107,127,75,95,115,67,83,107,59,75,95,51,63,83,43,55,71,35,43,59,31,35,47,23,27,35,19,19,23,11,11,15,7,7,219,195,187,203,179,167,191,163,155,175,151,139,163,135,123,151,123,111,135,111,95,123,99,83,107,87,71,95,75,59,83,63,
+    51,67,51,39,55,43,31,39,31,23,27,19,15,15,11,7,111,131,123,103,123,111,95,115,103,87,107,95,79,99,87,71,91,79,63,83,71,55,75,63,47,67,55,43,59,47,35,51,39,31,43,31,23,35,23,15,27,19,11,19,11,7,11,7,255,243,27,239,223,23,219,203,19,203,183,15,187,167,15,171,151,11,155,131,7,139,115,7,123,99,7,107,83,0,91,71,0,75,55,0,59,43,0,43,31,0,27,15,0,11,7,0,0,0,255,11,11,239,19,19,223,27,27,207,35,35,191,43,
+    43,175,47,47,159,47,47,143,47,47,127,47,47,111,47,47,95,43,43,79,35,35,63,27,27,47,19,19,31,11,11,15,43,0,0,59,0,0,75,7,0,95,7,0,111,15,0,127,23,7,147,31,7,163,39,11,183,51,15,195,75,27,207,99,43,219,127,59,227,151,79,231,171,95,239,191,119,247,211,139,167,123,59,183,155,55,199,195,55,231,227,87,127,191,255,171,231,255,215,255,255,103,0,0,139,0,0,179,0,0,215,0,0,255,0,0,255,243,147,255,247,199,255,255,255,159,91,83
+};
+
+byte hexen2palette[768] = //mxd
+{
+    0,0,0,0,0,0,8,8,8,16,16,16,24,24,24,32,32,32,40,40,40,48,48,48,56,56,56,64,64,64,72,72,72,80,80,80,84,84,84,88,88,88,96,96,96,104,104,104,112,112,112,120,120,120,128,128,128,136,136,136,148,148,148,156,156,156,168,168,168,180,180,180,184,184,184,196,196,196,204,204,204,212,212,212,224,224,224,232,232,232,240,240,240,252,252,252,8,8,12,16,16,20,24,24,28,28,32,36,36,36,44,44,44,52,48,52,60,56,56,68,64,64,72,76,
+    76,88,92,92,104,108,112,128,128,132,152,152,156,176,168,172,196,188,196,220,32,24,20,40,32,28,48,36,32,52,44,40,60,52,44,68,56,52,76,64,56,84,72,64,92,76,72,100,84,76,108,92,84,112,96,88,120,104,96,128,112,100,136,116,108,144,124,112,20,24,20,28,32,28,32,36,32,40,44,40,44,48,44,48,56,48,56,64,56,64,68,64,68,76,68,84,92,84,104,112,104,120,128,120,140,148,136,156,164,152,172,180,168,188,196,184,48,32,8,60,40,8,
+    72,48,16,84,56,20,92,64,28,100,72,36,108,80,44,120,92,52,136,104,60,148,116,72,160,128,84,168,136,92,180,144,100,188,152,108,196,160,116,204,168,124,16,20,16,20,28,20,24,32,24,28,36,28,32,44,32,36,48,36,40,56,40,44,60,44,48,68,48,52,76,52,60,84,60,68,92,64,76,100,72,84,108,76,92,116,84,100,128,92,24,12,8,32,16,8,40,20,8,52,24,12,60,28,12,68,32,12,76,36,16,84,44,20,92,48,24,100,56,28,112,64,32,120,72,36,128,80,
+    44,144,92,56,168,112,72,192,132,88,24,4,4,36,4,4,48,0,0,60,0,0,68,0,0,80,0,0,88,0,0,100,0,0,112,0,0,132,0,0,152,0,0,172,0,0,192,0,0,212,0,0,232,0,0,252,0,0,16,12,32,28,20,48,32,28,56,40,36,68,52,44,80,60,56,92,68,64,104,80,72,116,88,84,128,100,96,140,108,108,152,120,116,164,132,132,176,144,144,188,156,156,200,172,172,212,36,20,4,52,24,4,68,32,4,80,40,0,100,48,4,124,60,4,140,72,4,156,88,8,172,100,8,188,116,12,
+    204,128,12,220,144,16,236,160,20,252,184,56,248,200,80,248,220,120,20,16,4,28,24,8,36,32,8,44,40,12,52,48,16,56,56,16,64,64,20,68,72,24,72,80,28,80,92,32,84,104,40,88,116,44,92,128,52,92,140,52,92,148,56,96,160,64,60,16,16,72,24,24,84,28,28,100,36,36,112,44,44,124,52,48,140,64,56,152,76,64,44,20,8,56,28,12,72,32,16,84,40,20,96,44,28,112,52,32,124,56,40,140,64,48,24,20,16,36,28,20,44,36,28,56,44,32,64,52,36,72,
+    60,44,80,68,48,92,76,52,100,84,60,112,92,68,120,100,72,132,112,80,144,120,88,152,128,96,160,136,104,168,148,112,36,24,12,44,32,16,52,40,20,60,44,20,72,52,24,80,60,28,88,68,28,104,76,32,148,96,56,160,108,64,172,116,72,180,124,80,192,132,88,204,140,92,216,156,108,60,20,92,100,36,116,168,72,164,204,108,192,4,84,4,4,132,4,0,180,0,0,216,0,4,4,144,16,68,204,36,132,224,88,168,232,216,4,4,244,72,0,252,128,0,252,172,24,252,252,252
+};
+
+byte quake2palette[768] = //mxd
+{
+    0,0,0,15,15,15,31,31,31,47,47,47,63,63,63,75,75,75,91,91,91,107,107,107,123,123,123,139,139,139,155,155,155,171,171,171,187,187,187,203,203,203,219,219,219,235,235,235,99,75,35,91,67,31,83,63,31,79,59,27,71,55,27,63,47,23,59,43,23,51,39,19,47,35,19,43,31,19,39,27,15,35,23,15,27,19,11,23,15,11,19,15,7,15,11,7,95,95,111,91,91,103,91,83,95,87,79,91,83,75,83,79,71,75,71,63,67,63,59,59,59,55,55,51,47,47,47,43,43,
+    39,39,39,35,35,35,27,27,27,23,23,23,19,19,19,143,119,83,123,99,67,115,91,59,103,79,47,207,151,75,167,123,59,139,103,47,111,83,39,235,159,39,203,139,35,175,119,31,147,99,27,119,79,23,91,59,15,63,39,11,35,23,7,167,59,43,159,47,35,151,43,27,139,39,19,127,31,15,115,23,11,103,23,7,87,19,0,75,15,0,67,15,0,59,15,0,51,11,0,43,11,0,35,11,0,27,7,0,19,7,0,123,95,75,115,87,67,107,83,63,103,79,59,95,71,55,87,67,51,83,63,
+    47,75,55,43,67,51,39,63,47,35,55,39,27,47,35,23,39,27,19,31,23,15,23,15,11,15,11,7,111,59,23,95,55,23,83,47,23,67,43,23,55,35,19,39,27,15,27,19,11,15,11,7,179,91,79,191,123,111,203,155,147,215,187,183,203,215,223,179,199,211,159,183,195,135,167,183,115,151,167,91,135,155,71,119,139,47,103,127,23,83,111,19,75,103,15,67,91,11,63,83,7,55,75,7,47,63,7,39,51,0,31,43,0,23,31,0,15,19,0,7,11,0,0,0,139,87,87,131,79,79,
+    123,71,71,115,67,67,107,59,59,99,51,51,91,47,47,87,43,43,75,35,35,63,31,31,51,27,27,43,19,19,31,15,15,19,11,11,11,7,7,0,0,0,151,159,123,143,151,115,135,139,107,127,131,99,119,123,95,115,115,87,107,107,79,99,99,71,91,91,67,79,79,59,67,67,51,55,55,43,47,47,35,35,35,27,23,23,19,15,15,11,159,75,63,147,67,55,139,59,47,127,55,39,119,47,35,107,43,27,99,35,23,87,31,19,79,27,15,67,23,11,55,19,11,43,15,7,31,11,7,23,7,0,
+    11,0,0,0,0,0,119,123,207,111,115,195,103,107,183,99,99,167,91,91,155,83,87,143,75,79,127,71,71,115,63,63,103,55,55,87,47,47,75,39,39,63,35,31,47,27,23,35,19,15,23,11,7,7,155,171,123,143,159,111,135,151,99,123,139,87,115,131,75,103,119,67,95,111,59,87,103,51,75,91,39,63,79,27,55,67,19,47,59,11,35,47,7,27,35,0,19,23,0,11,15,0,0,255,0,35,231,15,63,211,27,83,187,39,95,167,47,95,143,51,95,123,51,255,255,255,255,255,
+    211,255,255,167,255,255,127,255,255,83,255,255,39,255,235,31,255,215,23,255,191,15,255,171,7,255,147,0,239,127,0,227,107,0,211,87,0,199,71,0,183,59,0,171,43,0,155,31,0,143,23,0,127,15,0,115,7,0,95,0,0,71,0,0,47,0,0,27,0,0,239,0,0,55,55,255,255,0,0,0,0,255,43,43,35,27,27,23,19,19,15,235,151,127,195,115,83,159,87,51,123,63,27,235,211,199,199,171,155,167,139,119,135,107,87,159,91,83
+};
+
+void // WHO TOUCHED MY PALET?
+LoadPalette(bspdata_t *bspdata)
+{
+    // Load Quake 2 palette
+    if (bspdata->loadversion == Q2_BSPVERSION) {
+        byte *palette;
+        char path[1024];
+        char colormap[] = "pics/colormap.pcx";
+
+        sprintf(path, "%s%s", gamedir, colormap);
+        if (FileTime(path) == -1 || !LoadPCX(path, nullptr, &palette, nullptr, nullptr)) {
+            if (_strcmpi(gamedir, basedir)) {
+                sprintf(path, "%s%s", basedir, colormap);
+                if (FileTime(path) == -1 || !LoadPCX(path, nullptr, &palette, nullptr, nullptr)) {
+                    logprint("WARNING: failed to load palette from '%s%s' or '%s%s'.\nUsing built-in palette.\n", gamedir, colormap, basedir, colormap);
+                    palette = quake2palette;
+                }
+            } else {
+                logprint("WARNING: failed to load palette from '%s%s'.\nUsing built-in palette.\n", gamedir, colormap);
+                palette = quake2palette;
+            }
+        }
+
+        for (int i = 0; i < 768; i++)
+            thepalette[i] = palette[i];
+
+    } else if (bspdata->hullcount == MAX_MAP_HULLS_H2) { // Gross hacks
+        // Copy Hexen 2 palette
+        for (int i = 0; i < 768; i++)
+            thepalette[i] = hexen2palette[i];
+    }
+}
+
+qvec3f Palette_GetColor(const int i)
+{
+    return qvec3f((float)thepalette[3 * i],
+                  (float)thepalette[3 * i + 1],
+                  (float)thepalette[3 * i + 2]);
+}
+
+qvec4f Texture_GetColor(const rgba_miptex_t *tex, const int i)
+{
+    const byte *data = (byte*)tex + tex->offset;
+    return qvec4f{ (float)data[i * 4], 
+                   (float)data[i * 4 + 1], 
+                   (float)data[i * 4 + 2],
+                   (float)data[i * 4 + 3] };
+}
+
+/*
+============================================================================
+PCX IMAGE
+============================================================================
+*/
+
+//mxd. Copied from https://github.com/qbism/q2tools-220/blob/f8f582fc02196955584542c95de8a45a138c9e42/common/lbmlib.c#L383
+typedef struct
+{
+    char	manufacturer;
+    char	version;
+    char	encoding;
+    char	bits_per_pixel;
+    unsigned short	xmin, ymin, xmax, ymax;
+    unsigned short	hres, vres;
+    unsigned char	palette[48];
+    char	reserved;
+    char	color_planes;
+    unsigned short	bytes_per_line;
+    unsigned short	palette_type;
+    char	filler[58];
+    unsigned char	data;			// unbounded
+} pcx_t;
+
+
+/*
+==============
+LoadPCX
+==============
+*/
+qboolean
+LoadPCX(const char *filename, byte **pixels, byte **palette, int *width, int *height)
+{
+    byte	*raw;
+    int runLength;
+
+    // Load the file
+    if (FileTime(filename) == -1) {
+        logprint("LoadPCX: Failed to load '%s'. File does not exist.\n", filename);
+        return false; //mxd. Because LoadFile will throw Error if the file doesn't exist... 
+    }
+    const int len = LoadFile(filename, reinterpret_cast<void **>(&raw));
+    if (len < 1) {
+        logprint("LoadPCX: Failed to load '%s'. File is empty.\n", filename);
+        return false;
+    }
+
+    // Parse the PCX file
+    pcx_t *pcx = reinterpret_cast<pcx_t *>(raw);
+    raw = &pcx->data;
+
+    pcx->xmin = LittleShort(pcx->xmin);
+    pcx->ymin = LittleShort(pcx->ymin);
+    pcx->xmax = LittleShort(pcx->xmax);
+    pcx->ymax = LittleShort(pcx->ymax);
+    pcx->hres = LittleShort(pcx->hres);
+    pcx->vres = LittleShort(pcx->vres);
+    pcx->bytes_per_line = LittleShort(pcx->bytes_per_line);
+    pcx->palette_type = LittleShort(pcx->palette_type);
+
+    if (pcx->manufacturer != 0x0a
+        || pcx->version != 5
+        || pcx->encoding != 1
+        || pcx->bits_per_pixel != 8
+        || pcx->xmax >= 640
+        || pcx->ymax >= 480) {
+        logprint("LoadPCX: Failed to load '%s'. Unsupported PCX file.\n", filename);
+        return false; //mxd
+    }
+
+
+    if (palette) {
+        *palette = static_cast<byte*>(malloc(768));
+        memcpy(*palette, reinterpret_cast<byte *>(pcx) + len - 768, 768);
+    }
+
+    if (width)
+        *width = pcx->xmax + 1;
+    if (height)
+        *height = pcx->ymax + 1;
+
+    if (!pixels)
+        return true; // No target array specified, so skip reading pixels
+
+    const int numbytes = (pcx->ymax + 1) * (pcx->xmax + 1); //mxd
+    byte *out = static_cast<byte*>(malloc(numbytes));
+    if (!out) {
+        logprint("LoadPCX: Failed to load '%s'. Couldn't allocate %i bytes of memory.\n", filename, numbytes);
+        return false; //mxd
+    }
+
+    *pixels = out;
+
+    byte *pix = out;
+
+    for (int y = 0; y <= pcx->ymax; y++, pix += pcx->xmax + 1) {
+        for (int x = 0; x <= pcx->xmax; ) {
+            int dataByte = *raw++;
+
+            if ((dataByte & 0xC0) == 0xC0) {
+                runLength = dataByte & 0x3F;
+                dataByte = *raw++;
+            } else {
+                runLength = 1;
+            }
+
+            while (runLength-- > 0)
+                pix[x++] = dataByte;
+        }
+    }
+
+    if (raw - reinterpret_cast<byte *>(pcx) > len) {
+        logprint("LoadPCX: File '%s' was malformed.\n", filename);
+        return false; //mxd
+    }
+
+    free(pcx);
+
+    return true;
+}
+
+/*
+============================================================================
+TARGA IMAGE
+============================================================================
+*/
+
+//mxd. Copied from https://github.com/qbism/q2tools-220/blob/f8f582fc02196955584542c95de8a45a138c9e42/common/lbmlib.c#L625
+typedef struct _TargaHeader {
+    unsigned char 	id_length, colormap_type, image_type;
+    unsigned short	colormap_index, colormap_length;
+    unsigned char	colormap_size;
+    unsigned short	x_origin, y_origin, width, height;
+    unsigned char	pixel_size, attributes;
+} TargaHeader;
+
+int
+fgetLittleShort(FILE *f)
+{
+    const byte b1 = fgetc(f);
+    const byte b2 = fgetc(f);
+    return static_cast<short>(b1 + b2 * 256);
+}
+
+int
+fgetLittleLong(FILE *f)
+{
+    const byte b1 = fgetc(f);
+    const byte b2 = fgetc(f);
+    const byte b3 = fgetc(f);
+    const byte b4 = fgetc(f);
+    return b1 + (b2 << 8) + (b3 << 16) + (b4 << 24);
+}
+
+/*
+=============
+LoadTGA
+=============
+*/
+qboolean
+LoadTGA(const char *filename, byte **pixels, int *width, int *height)
+{
+    byte			*pixbuf;
+    int				row, column;
+    TargaHeader		targa_header;
+
+    FILE *fin = fopen(filename, "rb");
+    if (!fin) {
+        logprint("LoadTGA: Failed to load '%s'. File does not exist.\n", filename);
+        return false; //mxd
+    }
+
+    targa_header.id_length = fgetc(fin);
+    targa_header.colormap_type = fgetc(fin);
+    targa_header.image_type = fgetc(fin);
+
+    targa_header.colormap_index = fgetLittleShort(fin);
+    targa_header.colormap_length = fgetLittleShort(fin);
+    targa_header.colormap_size = fgetc(fin);
+    targa_header.x_origin = fgetLittleShort(fin);
+    targa_header.y_origin = fgetLittleShort(fin);
+    targa_header.width = fgetLittleShort(fin);
+    targa_header.height = fgetLittleShort(fin);
+    targa_header.pixel_size = fgetc(fin);
+    targa_header.attributes = fgetc(fin);
+
+    if (targa_header.image_type != 2 && targa_header.image_type != 10) {
+        logprint("LoadTGA: Failed to load '%s'. Only type 2 and 10 targa RGB images supported.\n", filename);
+        return false; //mxd
+    }
+
+    if (targa_header.colormap_type != 0 || (targa_header.pixel_size != 32 && targa_header.pixel_size != 24)) {
+        logprint("LoadTGA: Failed to load '%s'. Only 32 or 24 bit images supported (no colormaps).\n", filename);
+        return false; //mxd
+    }
+
+    const int columns = targa_header.width;
+    const int rows = targa_header.height;
+    const int numPixels = columns * rows;
+
+    if (width)
+        *width = columns;
+    if (height)
+        *height = rows;
+
+    byte *targa_rgba = static_cast<byte*>(malloc(numPixels * 4));
+    *pixels = targa_rgba;
+
+    if (targa_header.id_length != 0)
+        fseek(fin, targa_header.id_length, SEEK_CUR);  // skip TARGA image comment
+
+    if (targa_header.image_type == 2) {  // Uncompressed, RGB images
+        for (row = rows - 1; row >= 0; row--) {
+            pixbuf = targa_rgba + row * columns * 4;
+            for (column = 0; column<columns; column++) {
+                unsigned char red, green, blue;
+                switch (targa_header.pixel_size) {
+                case 24:
+                    blue = getc(fin);
+                    green = getc(fin);
+                    red = getc(fin);
+                    *pixbuf++ = red;
+                    *pixbuf++ = green;
+                    *pixbuf++ = blue;
+                    *pixbuf++ = 255;
+                    break;
+                case 32:
+                    blue = getc(fin);
+                    green = getc(fin);
+                    red = getc(fin);
+                    const unsigned char alphabyte = getc(fin);
+                    *pixbuf++ = red;
+                    *pixbuf++ = green;
+                    *pixbuf++ = blue;
+                    *pixbuf++ = alphabyte;
+                    break;
+                }
+            }
+        }
+    } else if (targa_header.image_type == 10) {   // Runlength encoded RGB images
+        unsigned char red, green, blue, alphabyte, j;
+        for (row = rows - 1; row >= 0; row--) {
+            pixbuf = targa_rgba + row * columns * 4;
+            for (column = 0; column<columns; ) {
+                const unsigned char packetHeader = getc(fin);
+                const unsigned char packetSize = 1 + (packetHeader & 0x7f);
+                if (packetHeader & 0x80) {        // run-length packet
+                    switch (targa_header.pixel_size) {
+                    case 24:
+                        blue = getc(fin);
+                        green = getc(fin);
+                        red = getc(fin);
+                        alphabyte = 255;
+                        break;
+                    case 32:
+                        blue = getc(fin);
+                        green = getc(fin);
+                        red = getc(fin);
+                        alphabyte = getc(fin);
+                        break;
+                    }
+
+                    for (j = 0; j<packetSize; j++) {
+                        *pixbuf++ = red;
+                        *pixbuf++ = green;
+                        *pixbuf++ = blue;
+                        *pixbuf++ = alphabyte;
+                        column++;
+                        if (column == columns) { // run spans across rows
+                            column = 0;
+                            if (row>0)
+                                row--;
+                            else
+                                goto breakOut;
+                            pixbuf = targa_rgba + row * columns * 4;
+                        }
+                    }
+                } else {                         // non run-length packet
+                    for (j = 0; j<packetSize; j++) {
+                        switch (targa_header.pixel_size) {
+                        case 24:
+                            blue = getc(fin);
+                            green = getc(fin);
+                            red = getc(fin);
+                            *pixbuf++ = red;
+                            *pixbuf++ = green;
+                            *pixbuf++ = blue;
+                            *pixbuf++ = 255;
+                            break;
+                        case 32:
+                            blue = getc(fin);
+                            green = getc(fin);
+                            red = getc(fin);
+                            alphabyte = getc(fin);
+                            *pixbuf++ = red;
+                            *pixbuf++ = green;
+                            *pixbuf++ = blue;
+                            *pixbuf++ = alphabyte;
+                            break;
+                        }
+                        column++;
+                        if (column == columns) { // pixel packet run spans across rows
+                            column = 0;
+                            if (row>0)
+                                row--;
+                            else
+                                goto breakOut;
+                            pixbuf = targa_rgba + row * columns * 4;
+                        }
+                    }
+                }
+            }
+        breakOut:;
+        }
+    }
+
+    fclose(fin);
+
+    return true; //mxd
+}
+
+/*
+============================================================================
+WAL IMAGE
+============================================================================
+*/
+
+qboolean LoadWAL(const char *filename, byte **pixels, int *width, int *height)
+{
+    if (FileTime(filename) == -1) {
+        logprint("LoadWAL: Failed to load '%s'. File does not exist.\n", filename);
+        return false; // Because LoadFile will throw an Error if the file doesn't exist... 
+    }
+
+    q2_miptex_t	*mt;
+    const int len = LoadFile(filename, static_cast<void *>(&mt));
+    if (len < 1) {
+        logprint("LoadWAL: Failed to load '%s'. File is empty.\n", filename);
+        return false;
+    }
+
+    const int w = LittleLong(mt->width);
+    const int h = LittleLong(mt->height);
+    const int offset = LittleLong(mt->offsets[0]);
+    const int numbytes = w * h;
+    const int numpixels = numbytes * 4; // RGBA
+
+    if (width) *width = w;
+    if (height) *height = h;
+
+    byte *out = static_cast<byte*>(malloc(numpixels));
+    if (!out) {
+        logprint("LoadWAL: Failed to load '%s'. Couldn't allocate %i bytes of memory.\n", filename, numpixels);
+        return false;
+    }
+
+    *pixels = out;
+
+    for (int i = 0; i < numbytes; i++) {
+        const int palindex = reinterpret_cast<byte*>(mt)[offset + i];
+        out[i * 4]     = thepalette[palindex * 3];
+        out[i * 4 + 1] = thepalette[palindex * 3 + 1];
+        out[i * 4 + 2] = thepalette[palindex * 3 + 2];
+        out[i * 4 + 3] = (palindex == 255 ? 0 : 255); // Last palette index is transparent color
+    }
+
+    free(mt);
+
+    return true;
+}
+
+/*
+==============================================================================
+Load (Quake 2) / Convert (Quake, Hexen 2) textures from paletted to RGBA (mxd)
+==============================================================================
+*/
+
+static void
+WriteRGBATextureData(mbsp_t *bsp, const std::vector<rgba_miptex_t*> &tex_mips, const std::vector<byte*> &tex_bytes)
+{
+    // Step 1: create header and write it...
+    const int headersize = 4 + tex_mips.size() * 4;
+    dmiptexlump_t *miplmp = static_cast<dmiptexlump_t*>(malloc(headersize));
+    miplmp->nummiptex = tex_mips.size();
+
+    // Write data offsets to the header...
+    int totalsize = headersize; // total size of miptex_t + palette bytes
+    const int miptexsize = sizeof(rgba_miptex_t);
+    for (unsigned int i = 0; i < tex_mips.size(); i++) {
+        if (tex_mips[i] == nullptr) {
+            miplmp->dataofs[i] = -1;
+        } else {
+            miplmp->dataofs[i] = totalsize;
+            totalsize += miptexsize + (tex_mips[i]->width * tex_mips[i]->height) * 4; // RGBA
+        }
+    }
+
+    // Step 2: write rgba_miptex_t and palette bytes to byte array
+    byte *texdata, *texdatastart;
+    texdata = texdatastart = static_cast<byte*>(malloc(totalsize));
+    memcpy(texdata, miplmp, headersize);
+    texdata += headersize;
+
+    for (unsigned int i = 0; i < tex_mips.size(); i++) {
+        if (tex_mips[i] == nullptr)
+            continue;
+
+        // Write rgba_miptex_t
+        memcpy(texdata, tex_mips[i], miptexsize);
+        texdata += miptexsize;
+
+        // Write RGBA pixels
+        const int numpixels = (tex_mips[i]->width * tex_mips[i]->height) * 4; // RGBA
+        memcpy(texdata, tex_bytes[i], numpixels);
+        texdata += numpixels;
+    }
+
+    // Store in bsp->drgbatexdata...
+    bsp->drgbatexdata = reinterpret_cast<dmiptexlump_t*>(texdatastart);
+    bsp->rgbatexdatasize = totalsize;
+}
+
+static void AddTextureName(std::map<std::string, std::string> &texturenames, const char *texture)
+{
+    // See if an earlier texinfo allready got the value
+    if (texturenames.find(texture) != texturenames.end())
+        return;
+
+    char path[4][1024];
+    static const qboolean is_mod = _strcmpi(gamedir, basedir);
+
+    sprintf(path[0], "%stextures/%s.tga", gamedir, texture); // TGA, in mod dir...
+    sprintf(path[1], "%stextures/%s.tga", basedir, texture); // TGA, in game dir...
+    sprintf(path[2], "%stextures/%s.wal", gamedir, texture); // WAL, in mod dir...
+    sprintf(path[3], "%stextures/%s.wal", basedir, texture); // WAL, in game dir...
+
+    int c;
+    for (c = 0; c < 4; c++) {
+        // Skip paths at even indexes when running from game folder... 
+        if ((is_mod || c % 2 == 0) && FileTime(path[c]) != -1) {
+            texturenames[std::string{ texture }] = std::string{ path[c] };
+            break;
+        }
+    }
+
+    if (c == 4) {
+        if (is_mod)
+            logprint("WARNING: failed to find texture '%s'. Checked paths:\n'%s'\n'%s'\n'%s'\n'%s'\n", texture, path[0], path[1], path[2], path[3]);
+        else
+            logprint("WARNING: failed to find texture '%s'. Checked paths:\n'%s'\n'%s'\n", texture, path[0], path[2]);
+
+        // Store to preserve offset... 
+        texturenames[std::string{ texture }] = std::string{};
+    }
+}
+
+static void // Loads textures from disk and stores them in bsp->drgbatexdata (Quake 2)
+LoadTextures(mbsp_t *bsp)
+{
+    logprint("--- LoadTextures ---\n");
+
+    if (bsp->texdatasize) {
+        Error("ERROR: Expected an empty dtexdata lump...\n");
+        return;
+    }
+
+    // Step 1: gather all loadable textures...
+    std::map<std::string, std::string> texturenames; // <texture name, texture file path>
+    for (int i = 0; i < bsp->numtexinfo; i++)
+        AddTextureName(texturenames, bsp->texinfo[i].texture);
+
+    // Step 2: gather textures used by _project_texture. Yes, this means parsing dentdata twice...
+    auto entdicts = EntData_Parse(bsp->dentdata);
+    for (auto &entdict : entdicts) {
+        if (EntDict_StringForKey(entdict, "classname").find("light") == 0) {
+            auto tex = EntDict_StringForKey(entdict, "_project_texture");
+            if (!tex.empty()) AddTextureName(texturenames, tex.c_str());
+        }
+    }
+
+    // Step 3: load and convert to miptex_t, store texturename indices...
+    std::map<std::string, int> indicesbytexturename;
+    std::vector<rgba_miptex_t*> tex_mips{};
+    std::vector<byte*> tex_bytes{};
+    const int miptexsize = sizeof(rgba_miptex_t);
+    int counter = 0;
+
+    for (auto pair : texturenames) {
+        // Store texturename index...
+        indicesbytexturename[std::string{ pair.first }] = counter++;
+
+        // Add nullptrs to keep texture index in case of load problems...
+        tex_mips.push_back(nullptr);
+        tex_bytes.push_back(nullptr);
+        
+        // Find file extension
+        const int dpos = pair.second.rfind('.');
+        if (dpos == -1) {
+            if (!pair.second.empty()) // Missing texture warning was already displayed
+                logprint("WARNING: unexpected texture filename: '%s'\n", pair.second.c_str());
+            continue;
+        }
+        const std::string ext = pair.second.substr(dpos + 1);
+
+        // Load images as RGBA
+        int width, height;
+        byte *pixels;
+
+        if (string_iequals(ext, "tga")) {
+            if (!LoadTGA(pair.second.c_str(), &pixels, &width, &height)) 
+                continue;
+        } else if (string_iequals(ext, "wal")) {
+            if (!LoadWAL(pair.second.c_str(), &pixels, &width, &height)) 
+                continue;
+        } else {
+            logprint("WARNING: unsupported image format: '%s'\n", pair.second.c_str());
+            continue;
+        }
+
+        // Create rgba_miptex_t...
+        rgba_miptex_t *tex = static_cast<rgba_miptex_t*>(malloc(miptexsize));
+        strcpy(tex->name, pair.first.c_str());
+        tex->width = width;
+        tex->height = height;
+        tex->offset = miptexsize;
+
+        // Replace nullptrs with actual data...
+        tex_mips[tex_mips.size() - 1] = tex;
+        tex_bytes[tex_bytes.size() - 1] = pixels;
+    }
+
+    // Sanity checks...
+    Q_assert(tex_mips.size() == tex_bytes.size());
+    Q_assert(texturenames.size() == tex_bytes.size());
+    Q_assert(texturenames.size() == indicesbytexturename.size());
+
+    // Step 4: write data to bsp...
+    WriteRGBATextureData(bsp, tex_mips, tex_bytes);
+
+    // Step 5: set miptex indices to gtexinfo_t
+    for (int i = 0; i < bsp->numtexinfo; i++) {
+        gtexinfo_t *info = &bsp->texinfo[i];
+
+        const auto pair = indicesbytexturename.find(info->texture);
+        if(pair != indicesbytexturename.end())
+            info->miptex = pair->second;
+    }
+}
+
+static void // Converts paletted bsp->dtexdata textures to RGBA bsp->drgbatexdata textures (Quake / Hexen2)
+ConvertTextures(mbsp_t *bsp)
+{
+    if (!bsp->texdatasize) return;
+
+    logprint("--- ConvertTextures ---\n");
+
+    std::map<int, std::string> texturenamesbyindex;
+    std::vector<rgba_miptex_t*> tex_mips{};
+    std::vector<byte*> tex_bytes{};
+    const int miptexsize = sizeof(rgba_miptex_t);
+
+    // Step 1: store texture data and RGBA bytes in temporary arrays...
+    for (int i = 0; i < bsp->dtexdata->nummiptex; i++) {
+        const int ofs = bsp->dtexdata->dataofs[i];
+
+        // Pad to keep offsets...
+        if (ofs < 0) {
+            tex_mips.push_back(nullptr);
+            tex_bytes.push_back(nullptr);
+            continue;
+        }
+
+        miptex_t *miptex = (miptex_t *)((byte *)bsp->dtexdata + ofs);
+
+        // Create rgba_miptex_t...
+        rgba_miptex_t *tex = static_cast<rgba_miptex_t*>(malloc(miptexsize));
+        strcpy(tex->name, miptex->name);
+        tex->width = miptex->width;
+        tex->height = miptex->height;
+        tex->offset = miptexsize;
+
+        // Store texturename index...
+        texturenamesbyindex[i] = std::string{ tex->name };
+
+        // Convert to RGBA
+        const int numpalpixels = tex->width * tex->height;
+        byte *pixels = static_cast<byte*>(malloc(numpalpixels * 4)); //RGBA
+        const byte *data = reinterpret_cast<byte*>(miptex) + miptex->offsets[0];
+
+        for (int c = 0; c < numpalpixels; c++) {
+            const byte palindex = data[c];
+            auto color = Palette_GetColor(palindex);
+            for (int d = 0; d < 3; d++)
+                pixels[c * 4 + d] = static_cast<byte>(color[d]);
+            pixels[c * 4 + 3] = static_cast<byte>(palindex == 255 ? 0 : 255);
+        }
+
+        // Store...
+        tex_mips.push_back(tex);
+        tex_bytes.push_back(pixels);
+    }
+
+    // Sanity checks...
+    Q_assert(tex_mips.size() == tex_bytes.size());
+    Q_assert(bsp->dtexdata->nummiptex == tex_mips.size());
+
+    // Step 2: write data to bsp...
+    WriteRGBATextureData(bsp, tex_mips, tex_bytes);
+
+    // Step 3: set texturenames to gmiptex_t
+    for (int i = 0; i < bsp->numtexinfo; i++) {
+        gtexinfo_t *info = &bsp->texinfo[i];
+
+        const auto pair = texturenamesbyindex.find(info->miptex);
+        if(pair != texturenamesbyindex.end())
+            strcpy(info->texture, pair->second.c_str());
+    }
+}
+
+void // Expects correct palette and game/mod paths to be set
+LoadOrConvertTextures(mbsp_t *bsp)
+{
+    // Load or convert textures...
+    if (bsp->loadversion == Q2_BSPVERSION)
+        LoadTextures(bsp);
+    else if (bsp->texdatasize > 0)
+        ConvertTextures(bsp);
+    else
+        logprint("WARNING: failed to load or convert textures.\n");
+}

--- a/light/light.cc
+++ b/light/light.cc
@@ -25,6 +25,8 @@
 #include <light/light.hh>
 #include <light/phong.hh>
 #include <light/bounce.hh>
+#include <light/surflight.hh> //mxd
+#include <light/imglib.hh> //mxd
 #include <light/entities.hh>
 #include <light/ltface.hh>
 
@@ -106,6 +108,8 @@ vec3_t dump_face_point = {0,0,0};
 int dump_vertnum = -1;
 bool dump_vert;
 vec3_t dump_vert_point = {0,0,0};
+
+qboolean arghradcompat = false; //mxd
 
 lockable_setting_t *FindSetting(std::string name) {
     settingsdict_t sd = cfg_static.settings();
@@ -358,8 +362,6 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     logprint("--- LightWorld ---\n" );
     
     mbsp_t *const bsp = &bspdata->data.mbsp;
-    const unsigned char *lmshift_lump;
-    int i, j;
     if (bsp->dlightdata)
         free(bsp->dlightdata);
     if (lux_buffer)
@@ -393,7 +395,7 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     if (forcedscale)
         BSPX_AddLump(bspdata, "LMSHIFT", NULL, 0);
 
-    lmshift_lump = (const unsigned char *)BSPX_GetLump(bspdata, "LMSHIFT", NULL);
+    const unsigned char *lmshift_lump = (const unsigned char *)BSPX_GetLump(bspdata, "LMSHIFT", NULL);
     if (!lmshift_lump && write_litfile != ~0)
         faces_sup = NULL; //no scales, no lit2
     else
@@ -402,24 +404,25 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
         memset(faces_sup, 0, sizeof(*faces_sup) * bsp->numfaces);
         if (lmshift_lump)
         {
-            for (i = 0; i < bsp->numfaces; i++)
+            for (int i = 0; i < bsp->numfaces; i++)
                 faces_sup[i].lmscale = 1<<lmshift_lump[i];
         }
         else
         {
-            for (i = 0; i < bsp->numfaces; i++)
+            for (int i = 0; i < bsp->numfaces; i++)
                 faces_sup[i].lmscale = modelinfo.at(0)->lightmapscale;
         }
     }
 
     CalcualateVertexNormals(bsp);
     
-    if (cfg_static.bounce.boolValue()
-        && (debugmode == debugmode_none
-            || debugmode == debugmode_bounce
-            || debugmode == debugmode_bouncelights)) {
+    const qboolean bouncerequired = cfg_static.bounce.boolValue() && (debugmode == debugmode_none || debugmode == debugmode_bounce || debugmode == debugmode_bouncelights); //mxd
+    const qboolean isQuake2map = (bsp->loadversion == Q2_BSPVERSION); //mxd
+
+    if (bouncerequired || isQuake2map) {
         MakeTextureColors(bsp);
-        MakeBounceLights(cfg_static, bsp);
+        if (isQuake2map)   MakeSurfaceLights(cfg_static, bsp);
+        if (bouncerequired) MakeBounceLights(cfg_static, bsp);
     }
     
 #if 0
@@ -432,6 +435,9 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     RunThreadsOn(0, bsp->numfaces, LightThread, bsp);
 #endif
 
+    if (bouncerequired || isQuake2map) //mxd. Print some extra stats...
+        logprint("Indirect lights: %d bounce lights, %d surface lights in use.\n", BounceLights().size(), SurfaceLights().size());
+
     logprint("Lighting Completed.\n\n");
     bsp->lightdatasize = file_p - filebase;
     logprint("lightdatasize: %i\n", bsp->lightdatasize);
@@ -441,10 +447,10 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     {
         uint8_t *styles = (uint8_t *)malloc(sizeof(*styles)*4*bsp->numfaces);
         int32_t *offsets = (int32_t *)malloc(sizeof(*offsets)*bsp->numfaces);
-        for (i = 0; i < bsp->numfaces; i++)
+        for (int i = 0; i < bsp->numfaces; i++)
         {
             offsets[i] = faces_sup[i].lightofs;
-            for (j = 0; j < MAXLIGHTMAPS; j++)
+            for (int j = 0; j < MAXLIGHTMAPS; j++)
                 styles[i*4+j] = faces_sup[i].styles[j];
         }
         BSPX_AddLump(bspdata, "LMSTYLE", styles, sizeof(*styles)*4*bsp->numfaces);
@@ -498,18 +504,27 @@ LoadExtendedTexinfoFlags(const char *sourcefilename, const mbsp_t *bsp)
     fclose(texinfofile);
 }
 
+static const char* //mxd
+GetBaseDirName(bspdata_t *bspdata)
+{
+    if (bspdata->loadversion == Q2_BSPVERSION)
+        return "BASEQ2";
+    if (bspdata->hullcount == MAX_MAP_HULLS_H2)
+        return "DATA1";
+    return "ID1";
+}
+
 //obj
 
 static FILE *
 InitObjFile(const char *filename)
 {
-    FILE *objfile;
     char objfilename[1024];
     strcpy(objfilename, filename);
     StripExtension(objfilename);
     DefaultExtension(objfilename, ".obj");
     
-    objfile = fopen(objfilename, "wt");
+    FILE *objfile = fopen(objfilename, "wt");
     if (!objfile)
         Error("Failed to open %s: %s", objfilename, strerror(errno));
     
@@ -522,7 +537,7 @@ ExportObjFace(FILE *f, const mbsp_t *bsp, const bsp2_dface_t *face, int *vertcou
     // export the vertices and uvs
     for (int i=0; i<face->numedges; i++)
     {
-        int vertnum = Face_VertexAtIndex(bsp, face, i);
+        const int vertnum = Face_VertexAtIndex(bsp, face, i);
         const qvec3f normal = GetSurfaceVertexNormal(bsp, face, i);
         const float *pos = bsp->dvertexes[vertnum].point;
         fprintf(f, "v %.9g %.9g %.9g\n", pos[0], pos[1], pos[2]);
@@ -609,7 +624,7 @@ FindDebugFace(const mbsp_t *bsp)
     dump_facenum = facenum;
     
     const modelinfo_t *mi = ModelInfoForFace(bsp, facenum);
-    int modelnum = (mi->model - bsp->dmodels);
+    const int modelnum = (mi->model - bsp->dmodels);
     
     const char *texname = Face_TextureName(bsp, f);
     
@@ -676,7 +691,7 @@ static void CheckLitNeeded(const globalconfig_t &cfg)
     
     // check lights
     for (const auto &light : GetLights()) {
-        if (!VectorCompare(white, *light.color.vec3Value(), EQUAL_EPSILON)) {
+        if (!VectorCompare(white, *light.color.vec3Value(), EQUAL_EPSILON) || light.projectedmip != nullptr) { //mxd. Projected mips could also use .lit output
             SetLitNeeded();
             return;
         }
@@ -1023,6 +1038,9 @@ light_main(int argc, const char **argv)
         } else if ( !strcmp( argv[ i ], "-highlightseams" ) ) {
             logprint("Highlighting lightmap seams\n");
             debug_highlightseams = true;
+        } else if (!strcmp(argv[i], "-arghradcompat")) { //mxd
+            logprint("Arghrad entity keys conversion enabled\n");
+            arghradcompat = true;
         } else if ( !strcmp( argv[ i ], "-verbose" ) ) {
             verbose_log = true;
         } else if ( !strcmp( argv[ i ], "-help" ) ) {
@@ -1087,11 +1105,11 @@ light_main(int argc, const char **argv)
     else
     {
         if (write_litfile & 1)
-        logprint(".lit colored light output requested on command line.\n");
+            logprint(".lit colored light output requested on command line.\n");
         if (write_litfile & 2)
             logprint("BSPX colored light output requested on command line.\n");
         if (write_luxfile & 1)
-        logprint(".lux light directions output requested on command line.\n");
+            logprint(".lux light directions output requested on command line.\n");
         if (write_luxfile & 2)
             logprint("BSPX light directions output requested on command line.\n");
     }
@@ -1128,6 +1146,18 @@ light_main(int argc, const char **argv)
 
     loadversion = bspdata.version;
     ConvertBSPFormat(GENERIC_BSP, &bspdata);
+
+    //mxd. Use 1.0 rangescale as a default to better match with qrad3/arghrad
+    if (loadversion == Q2_BSPVERSION && !cfg.rangescale.isChanged())
+    {
+        const auto rs = new lockable_vec_t(cfg.rangescale.primaryName(), 1.0f, 0.0f, 100.0f);
+        cfg.rangescale = *rs; // Gross hacks to avoid displaying this in OptionsSummary...
+    }
+
+    //mxd. Load or convert textures...
+    SetQdirFromPath(GetBaseDirName(&bspdata), source);
+    LoadPalette(&bspdata);
+    LoadOrConvertTextures(bsp);
 
     LoadExtendedTexinfoFlags(source, bsp);
     LoadEntities(cfg, bsp);
@@ -1205,6 +1235,9 @@ light_main(int argc, const char **argv)
     logprint("%f lights tested, %f hits per sample point\n",
              static_cast<double>(total_light_rays) / static_cast<double>(total_samplepoints),
              static_cast<double>(total_light_ray_hits) / static_cast<double>(total_samplepoints));
+    logprint("%f surface lights tested, %f hits per sample point\n",
+        static_cast<double>(total_surflight_rays) / static_cast<double>(total_samplepoints),
+        static_cast<double>(total_surflight_ray_hits) / static_cast<double>(total_samplepoints)); //mxd
     logprint("%f bounce lights tested, %f hits per sample point\n",
              static_cast<double>(total_bounce_rays) / static_cast<double>(total_samplepoints),
              static_cast<double>(total_bounce_ray_hits) / static_cast<double>(total_samplepoints));

--- a/light/light.cc
+++ b/light/light.cc
@@ -432,32 +432,29 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     info.bsp = bsp;
     RunThreadsOn(0, info.all_batches.size(), LightBatchThread, &info);
 #else
+    logprint("--- LightThread ---\n"); //mxd
     RunThreadsOn(0, bsp->numfaces, LightThread, bsp);
 #endif
 
     if (bouncerequired || isQuake2map) //mxd. Print some extra stats...
-        logprint("Indirect lights: %d bounce lights, %d surface lights in use.\n", BounceLights().size(), SurfaceLights().size());
+        logprint("Indirect lights: %i bounce lights, %i surface lights (%i light points) in use.\n", BounceLights().size(), SurfaceLights().size(), TotalSurfacelightPoints());
 
     logprint("Lighting Completed.\n\n");
     bsp->lightdatasize = file_p - filebase;
     logprint("lightdatasize: %i\n", bsp->lightdatasize);
 
-
-    if (faces_sup)
-    {
+    if (faces_sup) {
         uint8_t *styles = (uint8_t *)malloc(sizeof(*styles)*4*bsp->numfaces);
         int32_t *offsets = (int32_t *)malloc(sizeof(*offsets)*bsp->numfaces);
-        for (int i = 0; i < bsp->numfaces; i++)
-        {
+        for (int i = 0; i < bsp->numfaces; i++) {
             offsets[i] = faces_sup[i].lightofs;
             for (int j = 0; j < MAXLIGHTMAPS; j++)
                 styles[i*4+j] = faces_sup[i].styles[j];
         }
         BSPX_AddLump(bspdata, "LMSTYLE", styles, sizeof(*styles)*4*bsp->numfaces);
         BSPX_AddLump(bspdata, "LMOFFSET", offsets, sizeof(*offsets)*bsp->numfaces);
-    }
-    else
-    { //kill this stuff if its somehow found.
+    } else { 
+        //kill this stuff if its somehow found.
         BSPX_AddLump(bspdata, "LMSTYLE", NULL, 0);
         BSPX_AddLump(bspdata, "LMOFFSET", NULL, 0);
     }

--- a/light/ltface.cc
+++ b/light/ltface.cc
@@ -20,6 +20,7 @@
 #include <light/light.hh>
 #include <light/phong.hh>
 #include <light/bounce.hh>
+#include <light/surflight.hh> //mxd
 #include <light/entities.hh>
 #include <light/trace.hh>
 #include <light/ltface.hh>
@@ -35,6 +36,7 @@ using namespace std;
 
 std::atomic<uint32_t> total_light_rays, total_light_ray_hits, total_samplepoints;
 std::atomic<uint32_t> total_bounce_rays, total_bounce_ray_hits;
+std::atomic<uint32_t> total_surflight_rays, total_surflight_ray_hits; //mxd
 std::atomic<uint32_t> fully_transparent_lightmaps;
 
 /* ======================================================================== */
@@ -289,8 +291,8 @@ CalcFaceExtents(const bsp2_dface_t *face,
     const gtexinfo_t *tex = &bsp->texinfo[face->texinfo];
 
     for (int i = 0; i < face->numedges; i++) {
-        int edge = bsp->dsurfedges[face->firstedge + i];
-        int vert = (edge >= 0) ? bsp->dedges[edge].v[0] : bsp->dedges[-edge].v[1];
+        const int edge = bsp->dsurfedges[face->firstedge + i];
+        const int vert = (edge >= 0) ? bsp->dedges[edge].v[0] : bsp->dedges[-edge].v[1];
         const dvertex_t *dvertex = &bsp->dvertexes[vert];
 
         vec3_t worldpoint;
@@ -738,12 +740,13 @@ CalcPoints(const modelinfo_t *modelinfo, const vec3_t offset, lightsurf_t *surf,
     }
 }
 
-static bool
+//mxd. That's Q1-specific. Also moved to bsputils.c as Face_IsTranslucent
+/*static bool
 Face_IsLiquid(const mbsp_t *bsp, const bsp2_dface_t *face)
 {
     const char *name = Face_TextureName(bsp, face);
     return name[0] == '*';
-}
+}*/
 
 static bool
 Lightsurf_Init(const modelinfo_t *modelinfo, const bsp2_dface_t *face,
@@ -793,7 +796,7 @@ Lightsurf_Init(const modelinfo_t *modelinfo, const bsp2_dface_t *face,
     }
     
     /* never receive dirtmapping on lit liquids */
-    if (Face_IsLiquid(bsp, face)) {
+    if (Face_IsTranslucent(bsp, face)) {
         lightsurf->nodirt = true;
     }
     
@@ -941,18 +944,11 @@ vec_t
 GetLightValue(const globalconfig_t &cfg, const light_t *entity, vec_t dist)
 {
     const float light = entity->light.floatValue();
-    vec_t value;
 
     //mxd. Apply falloff?
     const float lightdistance = entity->falloff.floatValue();
     if (lightdistance > 0.0f) {
-        if (entity->getFormula() != LF_LINEAR) {
-            logprint("WARNING: _falloff is currently only supported on linear (delay 0): light at (%f %f %f)\n",
-                     (*entity->origin.vec3Value())[0],
-                     (*entity->origin.vec3Value())[1],
-                     (*entity->origin.vec3Value())[2]);
-            // ignore _falloff key
-        } else {
+        if (entity->getFormula() == LF_LINEAR) {
             // Light can affect surface?
             if (lightdistance > dist)
                 return light * (1.0f - (dist / lightdistance));
@@ -964,7 +960,7 @@ GetLightValue(const globalconfig_t &cfg, const light_t *entity, vec_t dist)
     if (entity->getFormula() == LF_INFINITE || entity->getFormula() == LF_LOCALMIN)
         return light;
 
-    value = cfg.scaledist.floatValue() * entity->atten.floatValue() * dist;
+    vec_t value = cfg.scaledist.floatValue() * entity->atten.floatValue() * dist;
 
     switch (entity->getFormula()) {
     case LF_INVERSE:
@@ -981,6 +977,7 @@ GetLightValue(const globalconfig_t &cfg, const light_t *entity, vec_t dist)
             return (light + value < 0) ? light + value : 0;
     default:
         Error("Internal error: unknown light formula");
+        throw; //mxd. Silences compiler warning
     }
 }
 
@@ -1006,7 +1003,7 @@ GetLightValueWithAngle(const globalconfig_t &cfg, const light_t *entity, const v
     /* Check spotlight cone */
     float spotscale = 1;
     if (entity->spotlight) {
-        vec_t falloff = DotProduct(entity->spotvec, surfpointToLightDir);
+        const vec_t falloff = DotProduct(entity->spotvec, surfpointToLightDir);
         if (falloff > entity->spotfalloff) {
             return 0;
         }
@@ -1022,19 +1019,25 @@ GetLightValueWithAngle(const globalconfig_t &cfg, const light_t *entity, const v
     return add;
 }
 
-static void LightFace_SampleMipTex(miptex_t *tex, const float *projectionmatrix, const vec3_t point, float *result);
+static qboolean LightFace_SampleMipTex(rgba_miptex_t *tex, const float *projectionmatrix, const vec3_t point, float *result); //mxd. miptex_t -> rgba_miptex_t
 
 void
 GetLightContrib(const globalconfig_t &cfg, const light_t *entity, const vec3_t surfnorm, const vec3_t surfpoint, bool twosided,
                 vec3_t color_out, vec3_t surfpointToLightDir_out, vec3_t normalmap_addition_out, float *dist_out)
 {
-    float dist = GetDir(surfpoint, *entity->origin.vec3Value(), surfpointToLightDir_out);
-    float add = GetLightValueWithAngle(cfg, entity, surfnorm, surfpointToLightDir_out, dist, twosided);
+    const float dist = GetDir(surfpoint, *entity->origin.vec3Value(), surfpointToLightDir_out);
+    const float add = GetLightValueWithAngle(cfg, entity, surfnorm, surfpointToLightDir_out, dist, twosided);
     
     /* write out the final color */
     if (entity->projectedmip) {
         vec3_t col;
-        LightFace_SampleMipTex(entity->projectedmip, entity->projectionmatrix, surfpoint, col);
+        if(LightFace_SampleMipTex(entity->projectedmip, entity->projectionmatrix, surfpoint, col)) {
+            //mxd. Modulate by light color...
+            const auto entcol = *entity->color.vec3Value();
+            for (int i = 0; i < 3; i++)
+                col[i] *= entcol[i] * (1.0f / 255.0f);
+        }
+        
         VectorScale(col, add * (1.0f / 255.0f), color_out);
     } else {
         VectorScale(*entity->color.vec3Value(), add * (1.0f / 255.0f), color_out);
@@ -1043,6 +1046,33 @@ GetLightContrib(const globalconfig_t &cfg, const light_t *entity, const vec3_t s
     // write normalmap contrib
     VectorScale(surfpointToLightDir_out, add, normalmap_addition_out);
     
+    *dist_out = dist;
+}
+
+static qvec3f LightFace_ClosestOnFace(const surfacelight_t *vpl, const qvec3f pos, const qvec3f normal); //mxd
+
+static float //mxd
+SurfaceLight_DistanceScaler(const surfacelight_t *vpl, float dist)
+{
+    dist = qmax(dist, vpl->value / 6.0f); // Clamp away hotspots...
+    const float scale = vpl->value / (dist*dist);
+    return scale;
+}
+
+void //mxd
+GetSurfaceLightContrib(const globalconfig_t &cfg, const surfacelight_t *vpl, const vec3_t surfnorm, const vec3_t surfpoint,
+    vec3_t color_out, vec3_t surfpointToLightDir_out, float *dist_out)
+{
+    vec3_t lightpos;
+    glm_to_vec3_t(LightFace_ClosestOnFace(vpl, vec3_t_to_glm(surfpoint), vec3_t_to_glm(surfnorm)), lightpos);
+    
+    const float dist = GetDir(surfpoint, lightpos, surfpointToLightDir_out);
+    const float angle = DotProduct(surfpointToLightDir_out, surfnorm);
+    const float add = (angle < 0.0f ? 0.0f : SurfaceLight_DistanceScaler(vpl, dist) * vpl->areascaler * 8.0f); // Bounce light falloff...
+
+    // Write out the final color
+    VectorScale(vpl->color, add, color_out); // color_out is expected to be in [0..255] range, vpl->color is in [0..1] range.
+
     *dist_out = dist;
 }
 
@@ -1213,7 +1243,7 @@ CullLight(const light_t *entity, const lightsurf_t *lightsurf)
     
     vec3_t distvec;
     VectorSubtract(*entity->origin.vec3Value(), lightsurf->origin, distvec);
-    float dist = VectorLength(distvec) - lightsurf->radius;
+    const float dist = VectorLength(distvec) - lightsurf->radius;
     
     /* light is inside surface bounding sphere => can't cull */
     if (dist < 0) {
@@ -1226,15 +1256,6 @@ CullLight(const light_t *entity, const lightsurf_t *lightsurf)
     return fabs(GetLightValue(cfg, entity, dist)) <= fadegate;
 }
 
-byte thepalette[768] =
-{
-0,0,0,15,15,15,31,31,31,47,47,47,63,63,63,75,75,75,91,91,91,107,107,107,123,123,123,139,139,139,155,155,155,171,171,171,187,187,187,203,203,203,219,219,219,235,235,235,15,11,7,23,15,11,31,23,11,39,27,15,47,35,19,55,43,23,63,47,23,75,55,27,83,59,27,91,67,31,99,75,31,107,83,31,115,87,31,123,95,35,131,103,35,143,111,35,11,11,15,19,19,27,27,27,39,39,39,51,47,47,63,55,55,75,63,63,87,71,71,103,79,79,115,91,91,127,99,99,
-139,107,107,151,115,115,163,123,123,175,131,131,187,139,139,203,0,0,0,7,7,0,11,11,0,19,19,0,27,27,0,35,35,0,43,43,7,47,47,7,55,55,7,63,63,7,71,71,7,75,75,11,83,83,11,91,91,11,99,99,11,107,107,15,7,0,0,15,0,0,23,0,0,31,0,0,39,0,0,47,0,0,55,0,0,63,0,0,71,0,0,79,0,0,87,0,0,95,0,0,103,0,0,111,0,0,119,0,0,127,0,0,19,19,0,27,27,0,35,35,0,47,43,0,55,47,0,67,
-55,0,75,59,7,87,67,7,95,71,7,107,75,11,119,83,15,131,87,19,139,91,19,151,95,27,163,99,31,175,103,35,35,19,7,47,23,11,59,31,15,75,35,19,87,43,23,99,47,31,115,55,35,127,59,43,143,67,51,159,79,51,175,99,47,191,119,47,207,143,43,223,171,39,239,203,31,255,243,27,11,7,0,27,19,0,43,35,15,55,43,19,71,51,27,83,55,35,99,63,43,111,71,51,127,83,63,139,95,71,155,107,83,167,123,95,183,135,107,195,147,123,211,163,139,227,179,151,
-171,139,163,159,127,151,147,115,135,139,103,123,127,91,111,119,83,99,107,75,87,95,63,75,87,55,67,75,47,55,67,39,47,55,31,35,43,23,27,35,19,19,23,11,11,15,7,7,187,115,159,175,107,143,163,95,131,151,87,119,139,79,107,127,75,95,115,67,83,107,59,75,95,51,63,83,43,55,71,35,43,59,31,35,47,23,27,35,19,19,23,11,11,15,7,7,219,195,187,203,179,167,191,163,155,175,151,139,163,135,123,151,123,111,135,111,95,123,99,83,107,87,71,95,75,59,83,63,
-51,67,51,39,55,43,31,39,31,23,27,19,15,15,11,7,111,131,123,103,123,111,95,115,103,87,107,95,79,99,87,71,91,79,63,83,71,55,75,63,47,67,55,43,59,47,35,51,39,31,43,31,23,35,23,15,27,19,11,19,11,7,11,7,255,243,27,239,223,23,219,203,19,203,183,15,187,167,15,171,151,11,155,131,7,139,115,7,123,99,7,107,83,0,91,71,0,75,55,0,59,43,0,43,31,0,27,15,0,11,7,0,0,0,255,11,11,239,19,19,223,27,27,207,35,35,191,43,
-43,175,47,47,159,47,47,143,47,47,127,47,47,111,47,47,95,43,43,79,35,35,63,27,27,47,19,19,31,11,11,15,43,0,0,59,0,0,75,7,0,95,7,0,111,15,0,127,23,7,147,31,7,163,39,11,183,51,15,195,75,27,207,99,43,219,127,59,227,151,79,231,171,95,239,191,119,247,211,139,167,123,59,183,155,55,199,195,55,231,227,87,127,191,255,171,231,255,215,255,255,103,0,0,139,0,0,179,0,0,215,0,0,255,0,0,255,243,147,255,247,199,255,255,255,159,91,83
-};
 static void Matrix4x4_CM_Transform4(const float *matrix, const float *vector, float *product)
 {
     product[0] = matrix[0]*vector[0] + matrix[4]*vector[1] + matrix[8]*vector[2] + matrix[12]*vector[3];
@@ -1267,44 +1288,46 @@ static qboolean Matrix4x4_CM_Project (const vec3_t in, vec3_t out, const float *
         result = false; //beyond far clip plane
     return result;
 }
-static void LightFace_SampleMipTex(miptex_t *tex, const float *projectionmatrix, const vec3_t point, float *result)
+static qboolean LightFace_SampleMipTex(rgba_miptex_t *tex, const float *projectionmatrix, const vec3_t point, float *result) //mxd. miptex_t -> rgba_miptex_t
 {
     //okay, yes, this is weird, yes we're using a vec3_t for a coord...
     //this is because we're treating it like a cubemap. why? no idea.
-    float sfrac, tfrac, weight[4];
-    int sbase, tbase;
-    byte *data = (byte*)tex + tex->offsets[0], *pi[4];
+    float weight[4];
+    color_rgba pi[4];
+    color_rgba *data = (color_rgba*)((byte*)tex + tex->offset);
 
     vec3_t coord;
-    if (!Matrix4x4_CM_Project(point, coord, projectionmatrix) || coord[0] <= 0 || coord[0] >= 1 || coord[1] <= 0 || coord[1] >= 1)
+    if (!Matrix4x4_CM_Project(point, coord, projectionmatrix) || coord[0] <= 0 || coord[0] >= 1 || coord[1] <= 0 || coord[1] >= 1) {
         VectorSet(result, 0, 0, 0);
-    else
-    {
-        sfrac = (coord[0]) * tex->width;
-        sbase = sfrac;
+        return false; //mxd
+    } else {
+        float sfrac = (coord[0]) * (tex->width - 1); //mxd. We are sampling sbase+1 pixels, so multiplying by tex->width will result in an 1px overdraw, same for tbase
+        const int sbase = sfrac;
         sfrac -= sbase;
-        tfrac = (1-coord[1]) * tex->height;
-        tbase = tfrac;
+        float tfrac = (1-coord[1]) * (tex->height - 1);
+        const int tbase = tfrac;
         tfrac -= tbase;
 
-        pi[0] = thepalette + 3*data[((sbase+0)%tex->width) + (tex->width*((tbase+0)%tex->height))];     weight[0] = (1-sfrac)*(1-tfrac);
-        pi[1] = thepalette + 3*data[((sbase+1)%tex->width) + (tex->width*((tbase+0)%tex->height))];     weight[1] = (sfrac)*(1-tfrac);
-        pi[2] = thepalette + 3*data[((sbase+0)%tex->width) + (tex->width*((tbase+1)%tex->height))];     weight[2] = (1-sfrac)*(tfrac);
-        pi[3] = thepalette + 3*data[((sbase+1)%tex->width) + (tex->width*((tbase+1)%tex->height))];     weight[3] = (sfrac)*(tfrac);
+        pi[0] = data[((sbase+0)%tex->width) + (tex->width*((tbase+0)%tex->height))];     weight[0] = (1-sfrac)*(1-tfrac);
+        pi[1] = data[((sbase+1)%tex->width) + (tex->width*((tbase+0)%tex->height))];     weight[1] = (sfrac)*(1-tfrac);
+        pi[2] = data[((sbase+0)%tex->width) + (tex->width*((tbase+1)%tex->height))];     weight[2] = (1-sfrac)*(tfrac);
+        pi[3] = data[((sbase+1)%tex->width) + (tex->width*((tbase+1)%tex->height))];     weight[3] = (sfrac)*(tfrac);
         VectorSet(result, 0, 0, 0);
-        result[0]  = weight[0] * pi[0][0];
-        result[1]  = weight[0] * pi[0][1];
-        result[2]  = weight[0] * pi[0][2];
-        result[0] += weight[1] * pi[1][0];
-        result[1] += weight[1] * pi[1][1];
-        result[2] += weight[1] * pi[1][2];
-        result[0] += weight[2] * pi[2][0];
-        result[1] += weight[2] * pi[2][1];
-        result[2] += weight[2] * pi[2][2];
-        result[0] += weight[3] * pi[3][0];
-        result[1] += weight[3] * pi[3][1];
-        result[2] += weight[3] * pi[3][2];
+        result[0]  = weight[0] * pi[0].r;
+        result[1]  = weight[0] * pi[0].g;
+        result[2]  = weight[0] * pi[0].b;
+        result[0] += weight[1] * pi[1].r;
+        result[1] += weight[1] * pi[1].g;
+        result[2] += weight[1] * pi[1].b;
+        result[0] += weight[2] * pi[2].r;
+        result[1] += weight[2] * pi[2].g;
+        result[2] += weight[2] * pi[2].b;
+        result[0] += weight[3] * pi[3].r;
+        result[1] += weight[3] * pi[3].g;
+        result[2] += weight[3] * pi[3].b;
         VectorScale(result, 2, result);
+
+        return true; //mxd
     }
 }
 
@@ -1325,6 +1348,30 @@ GetDirectLighting(const globalconfig_t &cfg, raystream_t *rs, const vec3_t origi
     if (std::isnan(occlusion)) {
         // HACK: getting an invalid normal of (0, 0, 0).
         occlusion = 0.0f;
+    }
+
+    //mxd. Surface lights...
+    for (const surfacelight_t &vpl : SurfaceLights()) {
+        vec3_t surfpointToLightDir;
+        float surfpointToLightDist;
+        vec3_t color;
+
+        GetSurfaceLightContrib(cfg, &vpl, normal, origin, color, surfpointToLightDir, &surfpointToLightDist);
+
+        const float dirt = Dirt_GetScaleFactor(cfg, occlusion, nullptr, surfpointToLightDist, /* FIXME: pass */ nullptr);
+        VectorScale(color, dirt, color);
+        //VectorScale(color, entity.surflightscale.floatValue(), color); //TODO: entity.surflightscale?
+
+        // NOTE: Skip negative lights, which would make no sense to bounce!
+        if (LightSample_Brightness(color) <= fadegate)
+            continue;
+
+        vec3_t pos;
+        glm_to_vec3_t(vpl.pos, pos);
+        if (!TestLight(pos, origin, nullptr)) 
+            continue;
+
+        result[0] += vec3_t_to_glm(color);
     }
     
     for (const light_t &entity : GetLights()) {
@@ -1786,6 +1833,32 @@ LightFace_BounceLightsDebug(const lightsurf_t *lightsurf, lightmapdict_t *lightm
     }
 }
 
+static qvec3f //mxd
+LightFace_ClosestOnFace(const surfacelight_t *vpl, const qvec3f pos, const qvec3f normal)
+{
+    const qvec4f surfplane{ vpl->surfnormal[0], vpl->surfnormal[1], vpl->surfnormal[2], qv::dot(vpl->pos, vpl->surfnormal) };
+    qvec3f ppos = GLM_ProjectPointOntoPlane(surfplane, pos);
+
+    if (!GLM_EdgePlanes_PointInside(vpl->poly_edgeplanes, ppos)) {
+        ppos = GLM_ClosestPointOnPolyBoundary(vpl->poly, ppos).second;
+
+        // Nudge toward the surfacelight center...
+        vec3_t dir_t, ppos_t, vpl_pos_t;
+        glm_to_vec3_t(ppos, ppos_t);
+        glm_to_vec3_t(vpl->pos, vpl_pos_t);
+        const float dist = GetDir(ppos_t, vpl_pos_t, dir_t);
+        ppos += vec3_t_to_glm(dir_t) * (dist * 0.1f);
+    } else {
+        // Nudge away from target face plane
+        ppos += normal;
+    }
+
+    // Nudge away from surfacelight plane...
+    ppos += vpl->surfnormal;
+
+    return ppos;
+}
+
 // returns color in [0,255]
 static inline qvec3f
 BounceLight_ColorAtDist(const globalconfig_t &cfg, float area, const qvec3f &bounceLightColor, float dist)
@@ -1803,10 +1876,18 @@ BounceLight_ColorAtDist(const globalconfig_t &cfg, float area, const qvec3f &bou
     return result;
 }
 
+//mxd. Returns color in [0,255]
+static qvec3f
+SurfaceLight_ColorAtDist(const globalconfig_t &cfg, const surfacelight_t *vpl, float dist)
+{
+    const float scale = SurfaceLight_DistanceScaler(vpl, dist);
+    return vec3_t_to_glm(vpl->color) * vpl->areascaler * (76.0f * scale); // Surface light falloff...
+}
+
 // dir: vpl -> sample point direction
 // returns color in [0,255]
 static inline qvec3f
-GetIndirectLighting (const globalconfig_t &cfg, const bouncelight_t *vpl, const qvec3f &bounceLightColor, const qvec3f &dir, float dist, const qvec3f &origin, const qvec3f &normal)
+GetIndirectLighting (const globalconfig_t &cfg, const bouncelight_t *vpl, const qvec3f &bounceLightColor, const qvec3f &dir, const float dist, const qvec3f &origin, const qvec3f &normal)
 {
     const float dp1 = qv::dot(vpl->surfnormal, dir);
     if (dp1 < 0.0f)
@@ -1823,14 +1904,38 @@ GetIndirectLighting (const globalconfig_t &cfg, const bouncelight_t *vpl, const 
     // apply angle scale
     const qvec3f resultscaled = result * dp1 * dp2;
     
-    if (dp1 < 0) {
+    /*if (dp1 < 0) { //mxd. But it's const and was already checked above?
         Q_assert(!std::isnan(dp1));
-    }
+    }*/
     
     Q_assert(!std::isnan(resultscaled[0]));
     Q_assert(!std::isnan(resultscaled[1]));
     Q_assert(!std::isnan(resultscaled[2]));
     
+    return resultscaled;
+}
+
+// dir: vpl -> sample point direction
+//mxd. returns color in [0,255]
+static qvec3f
+GetSurfaceLighting(const globalconfig_t &cfg, const surfacelight_t *vpl, const qvec3f &dir, const float dist, const qvec3f &normal)
+{
+    qvec3f result{0};
+    const float dp1 = qv::dot(vpl->surfnormal, dir);
+    if (dp1 < 0.0f) return result; // sample point behind vpl
+
+    const qvec3f sp_vpl = dir * -1.0f;
+    float dp2 = qv::dot(sp_vpl, normal);
+    if (dp2 < 0.0f) return result; // vpl behind sample face
+
+    // Get light contribution
+    result = SurfaceLight_ColorAtDist(cfg, vpl , dist);
+    dp2 = 0.5f + dp2 * 0.5f; // Rescale a bit to brighten the faces nearly-perpendicular to the surface light plane...
+    
+    // Apply angle scale
+    const qvec3f resultscaled = result * dp1 * dp2;
+
+    Q_assert(!std::isnan(resultscaled[0]) && !std::isnan(resultscaled[1]) && !std::isnan(resultscaled[2]));
     return resultscaled;
 }
 
@@ -1848,10 +1953,23 @@ BounceLight_SphereCull(const mbsp_t *bsp, const bouncelight_t *vpl, const lights
     // get light contribution
     const qvec3f color = BounceLight_ColorAtDist(cfg, vpl->area, vpl->componentwiseMaxColor, dist);
     
-    if (LightSample_Brightness(color) < 0.25f)
+    return LightSample_Brightness(color) < 0.25f;
+}
+
+static bool //mxd
+SurfaceLight_SphereCull(const surfacelight_t *vpl, const lightsurf_t *lightsurf)
+{
+    if (!novisapprox && AABBsDisjoint(vpl->mins, vpl->maxs, lightsurf->mins, lightsurf->maxs))
         return true;
-    
-    return false;
+
+    const globalconfig_t &cfg = *lightsurf->cfg;
+    const qvec3f dir = vec3_t_to_glm(lightsurf->origin) - LightFace_ClosestOnFace(vpl, vec3_t_to_glm(lightsurf->origin), vec3_t_to_glm(lightsurf->snormal)); // vpl -> sample point
+    const float dist = qv::length(dir) - lightsurf->radius;
+
+    // get light contribution
+    const qvec3f color = SurfaceLight_ColorAtDist(cfg, vpl, dist);
+
+    return LightSample_Brightness(color) < 0.25f;
 }
 
 static void
@@ -2050,6 +2168,83 @@ LightFace_Bounce(const mbsp_t *bsp, const bsp2_dface_t *face, const lightsurf_t 
 #endif
 }
 
+static void //mxd
+LightFace_SurfaceLight(const lightsurf_t *lightsurf, lightmapdict_t *lightmaps)
+{
+    const globalconfig_t &cfg = *lightsurf->cfg;
+
+    for (const surfacelight_t &vpl : SurfaceLights()) {
+        if (SurfaceLight_SphereCull(&vpl, lightsurf))
+            continue;
+
+        raystream_t *rs = lightsurf->stream;
+        rs->clearPushedRays();
+
+        for (int i = 0; i < lightsurf->numpoints; i++) {
+            if (lightsurf->occluded[i])
+                continue;
+
+            const qvec3f lightsurf_pos = vec3_t_to_glm(lightsurf->points[i]);
+            const qvec3f lightsurf_normal = vec3_t_to_glm(lightsurf->normals[i]);
+            const qvec3f pos = LightFace_ClosestOnFace(&vpl, lightsurf_pos, lightsurf_normal);
+            qvec3f dir = lightsurf_pos - pos;
+            const float dist = qv::length(dir);
+            if (dist == 0.0f)
+                continue; // FIXME: nudge or something
+
+            dir /= dist;
+
+            const qvec3f indirect = GetSurfaceLighting(cfg, &vpl, dir, dist, vec3_t_to_glm(lightsurf->normals[i]));
+
+            if (LightSample_Brightness(indirect) < 0.25)
+                continue;
+
+            vec3_t vplPos, vplDir, vplColor;
+            glm_to_vec3_t(pos, vplPos);
+            glm_to_vec3_t(dir, vplDir);
+            glm_to_vec3_t(indirect, vplColor);
+
+            rs->pushRay(i, vplPos, vplDir, dist, lightsurf->modelinfo, vplColor);
+        }
+
+        if (!rs->numPushedRays())
+            continue;
+
+        total_surflight_rays += rs->numPushedRays();
+        rs->tracePushedRaysOcclusion();
+
+        const int lightmapstyle = 0;
+        lightmap_t *lightmap = Lightmap_ForStyle(lightmaps, lightmapstyle, lightsurf);
+
+        bool hit = false;
+        const int numrays = rs->numPushedRays();
+        for (int j = 0; j < numrays; j++) {
+            if (rs->getPushedRayOccluded(j))
+                continue;
+
+            const int i = rs->getPushedRayPointIndex(j);
+            vec3_t indirect = { 0 };
+            rs->getPushedRayColor(j, indirect);
+
+            Q_assert(!std::isnan(indirect[0]));
+
+            // Use dirt scaling on the surface lighting.
+            const vec_t dirtscale = Dirt_GetScaleFactor(cfg, lightsurf->occlusion[i], nullptr, 0.0, lightsurf);
+            VectorScale(indirect, dirtscale, indirect);
+
+            lightsample_t *sample = &lightmap->samples[i];
+            VectorAdd(sample->color, indirect, sample->color);
+
+            hit = true;
+            ++total_surflight_ray_hits;
+        }
+
+        // If surface light contributed anything, save.
+        if (hit)
+            Lightmap_Save(lightmaps, lightsurf, lightmap, lightmapstyle);
+    }
+}
+
 static void
 LightFace_OccludedDebug(lightsurf_t *lightsurf, lightmapdict_t *lightmaps)
 {
@@ -2179,8 +2374,8 @@ void SetupDirt(globalconfig_t &cfg) {
     }
     
     /* calculate angular steps */
-    float angleStep = DEG2RAD( 360.0f / DIRT_NUM_ANGLE_STEPS );
-    float elevationStep = DEG2RAD( cfg.dirtAngle.floatValue() / DIRT_NUM_ELEVATION_STEPS );
+    const float angleStep = (float)DEG2RAD( 360.0f / DIRT_NUM_ANGLE_STEPS );
+    const float elevationStep = (float)DEG2RAD( cfg.dirtAngle.floatValue() / DIRT_NUM_ELEVATION_STEPS );
 
     /* iterate angle */
     float angle = 0.0f;
@@ -2391,12 +2586,12 @@ LightFace_ScaleAndClamp(const lightsurf_t *lightsurf, lightmapdict_t *lightmaps)
             /* Scale and clamp any out-of-range samples */
             vec_t maxcolor = 0;
             VectorScale(color, cfg.rangescale.floatValue(), color);
-            for (int i = 0; i < 3; i++) {
-                color[i] = pow( color[i] / 255.0f, 1.0 / cfg.lightmapgamma.floatValue() ) * 255.0f;
+            for (int c = 0; c < 3; c++) {
+                color[c] = pow( color[c] / 255.0f, 1.0 / cfg.lightmapgamma.floatValue() ) * 255.0f;
             }
-            for (int i = 0; i < 3; i++) {
-                if (color[i] > maxcolor) {
-                    maxcolor = color[i];
+            for (int c = 0; c < 3; c++) {
+                if (color[c] > maxcolor) {
+                    maxcolor = color[c];
                 }
             }
             if (maxcolor > 255) {
@@ -2511,7 +2706,7 @@ LightmapColorsToGLMVector(const lightsurf_t *lightsurf, const lightmap_t *lm)
     for (int i=0; i<lightsurf->numpoints; i++) {
         const vec_t *color = lm->samples[i].color;
         const float alpha = lightsurf->occluded[i] ? 0.0f : 1.0f;
-        res.push_back(qvec4f(color[0], color[1], color[2], alpha));
+        res.emplace_back(color[0], color[1], color[2], alpha); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     }
     return res;
 }
@@ -2523,7 +2718,7 @@ LightmapNormalsToGLMVector(const lightsurf_t *lightsurf, const lightmap_t *lm)
     for (int i=0; i<lightsurf->numpoints; i++) {
         const vec_t *color = lm->samples[i].direction;
         const float alpha = lightsurf->occluded[i] ? 0.0f : 1.0f;
-        res.push_back(qvec4f(color[0], color[1], color[2], alpha));
+        res.emplace_back(color[0], color[1], color[2], alpha); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     }
     return res;
 }
@@ -2806,7 +3001,7 @@ WriteLightmaps(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const 
         }
         
         const float avgb = Lightmap_AvgBrightness(&lightmap, lightsurf);
-        sortable.push_back({ avgb, &lightmap });
+        sortable.emplace_back(avgb, &lightmap); //mxd. https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html
     }
     
     // sort in descending order of average brightness
@@ -2989,8 +3184,6 @@ LightFace(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const globa
         return;
     }    
     
-    const char *texname = Face_TextureName(bsp, face);
-    
     /* One extra lightmap is allocated to simplify handling overflow */
 
     /* some surfaces don't need lightmaps */
@@ -3006,19 +3199,22 @@ LightFace(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const globa
         for (int i = 0; i < MAXLIGHTMAPS; i++)
             face->styles[i] = 255;
     }
+
+    /* don't bother with degenerate faces */
+    if (face->numedges < 3)
+        return;
+
     if (!Face_IsLightmapped(bsp, face))
         return;
-    
+
+    const char *texname = Face_TextureName(bsp, face);
+
     /* don't save lightmaps for "trigger" texture */
     if (!Q_strcasecmp(texname, "trigger"))
         return;
     
     /* don't save lightmaps for "skip" texture */
     if (!Q_strcasecmp(texname, "skip"))
-        return;
-    
-    /* don't bother with degenerate faces */
-    if (face->numedges < 3)
         return;
     
     /* all good, this face is going to be lightmapped. */
@@ -3029,7 +3225,7 @@ LightFace(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const globa
      * lit water in mind. In that case receive light from both top and bottom.
      * (lit will only be rendered in compatible engines, but degrades gracefully.)
      */
-    if (texname[0] == '*') {
+    if (/* texname[0] == '*' */ Face_IsTranslucent(bsp, face)) { //mxd
         lightsurf->twosided = true;
     }
     
@@ -3066,14 +3262,22 @@ LightFace(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const globa
                 if (sun.sunlight > 0)
                     LightFace_Sky (&sun, lightsurf, lightmaps);
 
+            //mxd. Add surface lights...
+            LightFace_SurfaceLight(lightsurf, lightmaps);
+
             /* add indirect lighting */
             LightFace_Bounce(bsp, face, lightsurf, lightmaps);
         }
         
-        /* minlight - Use the greater of global or model minlight. */
-        if (lightsurf->minlight > cfg.minlight.floatValue())
+        /* minlight - Use Q2 surface light, or the greater of global or model minlight. */
+        const gtexinfo_t *texinfo = Face_Texinfo(bsp, face); //mxd. Surface lights...
+        if (texinfo != nullptr && texinfo->value > 0 && texinfo->flags & Q2_SURF_LIGHT) {
+            vec3_t color;
+            Face_LookupTextureColor(bsp, face, color);
+            LightFace_Min(bsp, face, color, texinfo->value * 2.0f, lightsurf, lightmaps); // Playing by the eye here... 2.0 == 256 / 128; 128 is the light value, at which the surface is renered fullbright, when using arghrad3
+        } else if (lightsurf->minlight > cfg.minlight.floatValue()) {
             LightFace_Min(bsp, face, lightsurf->minlight_color, lightsurf->minlight, lightsurf, lightmaps);
-        else {
+        } else {
             const float light = cfg.minlight.floatValue();
             vec3_t color;
             VectorCopy(*cfg.minlight_color.vec3Value(), color);

--- a/light/surflight.cc
+++ b/light/surflight.cc
@@ -1,0 +1,155 @@
+/*  Copyright (C) 1996-1997  Id Software, Inc.
+Copyright (C) 2018 MaxED
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See file, 'COPYING', for details.
+*/
+
+#include <cassert>
+#include <cstdio>
+#include <iostream>
+
+#include <light/light.hh>
+#include <light/bounce.hh>
+#include <light/surflight.hh>
+#include <light/ltface.hh>
+
+#include <common/polylib.hh>
+#include <common/bsputils.hh>
+
+#include <vector>
+#include <map>
+#include <mutex>
+#include <string>
+
+#include <common/qvec.hh>
+
+using namespace std;
+using namespace polylib;
+
+mutex surfacelights_lock;
+std::vector<surfacelight_t> surfacelights;
+std::map<int, std::vector<int>> surfacelightsByFacenum;
+
+struct make_surface_lights_args_t {
+    const mbsp_t *bsp;
+    const globalconfig_t *cfg;
+};
+
+static void
+AddSurfaceLight(const mbsp_t *bsp, const bsp2_dface_t *face, const float area, const vec3_t pos, const vec3_t surfnormal, const vec3_t color, const float lightvalue)
+{
+    surfacelight_t l;
+    l.poly = GLM_FacePoints(bsp, face);
+    l.poly_edgeplanes = GLM_MakeInwardFacingEdgePlanes(l.poly);
+    l.pos = vec3_t_to_glm(pos);
+    l.areascaler = ((area / 4.0f) / 128.0f);
+
+    // Store surfacelight settings...
+    l.value = lightvalue;
+    VectorCopy(color, l.color);
+
+    l.surfnormal = vec3_t_to_glm(surfnormal);
+    VectorSet(l.mins, 0, 0, 0);
+    VectorSet(l.maxs, 0, 0, 0);
+
+    if (!novisapprox)
+        EstimateVisibleBoundsAtPoint(pos, l.mins, l.maxs);
+
+    unique_lock<mutex> lck{ surfacelights_lock };
+    surfacelights.push_back(l);
+
+    const int index = static_cast<int>(surfacelights.size()) - 1;
+    surfacelightsByFacenum[Face_GetNum(bsp, face)].push_back(index);
+}
+
+static void *
+MakeSurfaceLightsThread(void *arg)
+{
+    const mbsp_t *bsp = static_cast<make_surface_lights_args_t *>(arg)->bsp;
+
+    while (true) {
+        const int i = GetThreadWork();
+        if (i == -1) break;
+
+        const bsp2_dface_t *face = BSP_GetFace(bsp, i);
+
+        // Face casts light?
+        const gtexinfo_t *info = Face_Texinfo(bsp, face);
+        if (info == nullptr) continue;
+        if (!(info->flags & Q2_SURF_LIGHT) || info->value == 0) {
+            if (info->flags & Q2_SURF_LIGHT) {
+                vec3_t wc;
+                WindingCenter(WindingFromFace(bsp, face), wc);
+                logprint("WARNING: surface light '%s' at [%s] has 0 intensity.\n", Face_TextureName(bsp, face), VecStr(wc));
+            }
+            continue;
+        }
+
+        // Grab some info about the face winding
+        winding_t *winding = WindingFromFace(bsp, face);
+        const float facearea = WindingArea(winding);
+
+        // Avoid small, or zero-area faces
+        if (facearea < 1) continue;
+
+        plane_t faceplane;
+        WindingPlane(winding, faceplane.normal, &faceplane.dist);
+
+        vec3_t facemidpoint;
+        WindingCenter(winding, facemidpoint);
+        VectorMA(facemidpoint, 1, faceplane.normal, facemidpoint); // lift 1 unit
+
+        // Get texture color
+        vec3_t blendedcolor = { 0, 0, 0 };
+        vec3_t texturecolor;
+        Face_LookupTextureColor(bsp, face, texturecolor);
+
+        // Calculate Q2 surface light color and strength
+        const float scaler = info->value / 256.0f; // Playing by the eye here...
+        for (int k = 0; k < 3; k++)
+            blendedcolor[k] = texturecolor[k] * scaler / 255.0f; // Scale by light value, convert to [0..1] range...
+
+        AddSurfaceLight(bsp, face, facearea, facemidpoint, faceplane.normal, blendedcolor, info->value);
+    }
+
+    return nullptr;
+}
+
+const std::vector<surfacelight_t> &SurfaceLights()
+{
+    return surfacelights;
+}
+
+// No surflight_debug (yet?), so unused...
+const std::vector<int> &SurfaceLightsForFaceNum(int facenum)
+{
+    const auto &vec = surfacelightsByFacenum.find(facenum);
+    if (vec != surfacelightsByFacenum.end()) 
+        return vec->second;
+
+    static std::vector<int> empty;
+    return empty;
+}
+
+void // Quake 2 surface lights
+MakeSurfaceLights(const globalconfig_t &cfg, const mbsp_t *bsp)
+{
+    logprint("--- MakeSurfaceLights ---\n");
+
+    make_surface_lights_args_t args { bsp,  &cfg };
+    RunThreadsOn(0, bsp->numfaces, MakeSurfaceLightsThread, static_cast<void *>(&args));
+}

--- a/light/trace_embree.cc
+++ b/light/trace_embree.cc
@@ -165,7 +165,7 @@ sceneinfo filtergeom; // conditional occluders.. needs to run ray intersection f
 
 static const mbsp_t *bsp_static;
 
-void ErrorCallback(const RTCError code, const char* str)
+void ErrorCallback(void* userptr, const RTCError code, const char* str)
 {
     printf("RTC Error %d: %s\n", code, str);
 }
@@ -181,6 +181,7 @@ Embree_SceneinfoForGeomID(unsigned int geomID)
         return filtergeom;
     } else {
         Error("unexpected geomID");
+        throw; //mxd. Added to silence compiler warning
     }
 }
 
@@ -288,7 +289,7 @@ Embree_FilterFuncN(int* valid,
             // we hit a dynamic shadow caster. reject the hit, but store the
             // info about what we hit.
             
-            int style = hit_modelinfo->switchshadstyle.intValue();
+            const int style = hit_modelinfo->switchshadstyle.intValue();
             
             AddDynamicOccluderToRay(context, rayIndex, style);
             
@@ -299,20 +300,36 @@ Embree_FilterFuncN(int* valid,
         
         // test fence textures and glass
         const bsp2_dface_t *face = Embree_LookupFace(geomID, primID);
-        const char *name = Face_TextureName(bsp_static, face);
         
-        const float alpha = hit_modelinfo->alpha.floatValue();
-        const bool isFence = (name[0] == '{');
-        const bool isGlass = (alpha < 1.0f);
+        
+        float alpha = hit_modelinfo->alpha.floatValue();
+
+        //mxd
+        bool isFence, isGlass;
+        if(bsp_static->loadversion == Q2_BSPVERSION) {
+            const int contents = Face_Contents(bsp_static, face);
+            isFence = ((contents & Q2_SURF_TRANSLUCENT) == Q2_SURF_TRANSLUCENT); // KMQuake 2-specific. Use texture alpha chanel when both flags are set.
+            isGlass = !isFence && (contents & Q2_SURF_TRANSLUCENT);
+            if(isGlass)
+                alpha = (contents & Q2_SURF_TRANS33 ? 0.66f : 0.33f);
+        } else {
+            const char *name = Face_TextureName(bsp_static, face);
+            isFence = (name[0] == '{');
+            isGlass = (alpha < 1.0f);
+        }
         
         if (isFence || isGlass) {
             vec3_t hitpoint;
             Embree_RayEndpoint(ray, potentialHit, N, i, hitpoint);
-            const int sample = SampleTexture(face, bsp_static, hitpoint);
+            const color_rgba sample = SampleTexture(face, bsp_static, hitpoint); //mxd. Palette index -> color_rgba
         
             if (isGlass) {
                 // hit glass...
                 
+                //mxd. Adjust alpha by texture alpha?
+                if (sample.a < 255)
+                    alpha = sample.a / 255.0f;
+
                 vec3_t rayDir = {
                     RTCRayN_dir_x(ray, N, i),
                     RTCRayN_dir_y(ray, N, i),
@@ -332,9 +349,8 @@ Embree_FilterFuncN(int* valid,
                 // only pick up the color of the glass on the _exiting_ side of the glass.
                 // (we currently trace "backwards", from surface point --> light source)
                 if (raySurfaceCosAngle < 0) {
-                    vec3_t samplecolor;
-                    glm_to_vec3_t(Palette_GetColor(sample), samplecolor);
-                    VectorScale(samplecolor, 1/255.0, samplecolor);
+                    vec3_t samplecolor { (float)sample.r, (float)sample.g, (float)sample.b };
+                    VectorScale(samplecolor, 1/255.0f, samplecolor);
                     
                     AddGlassToRay(context, rayIndex, alpha, samplecolor);
                 }
@@ -344,9 +360,8 @@ Embree_FilterFuncN(int* valid,
                 continue;
             }
             
-            
             if (isFence) {
-                if (sample == 255) {
+                if (sample.a < 255) {
                     // reject hit
                     valid[i] = INVALID;
                     continue;
@@ -504,13 +519,13 @@ void FreeWindings(std::vector<winding_t *> &windings)
 }
 
 void
-MakeFaces_r(const mbsp_t *bsp, int nodenum, std::vector<plane_t> *planes, std::vector<winding_t *> *result)
+MakeFaces_r(const mbsp_t *bsp, const int nodenum, std::vector<plane_t> *planes, std::vector<winding_t *> *result)
 {
     if (nodenum < 0) {
-        int leafnum = -nodenum - 1;
+        const int leafnum = -nodenum - 1;
         const mleaf_t *leaf = &bsp->dleafs[leafnum];
         
-        if (leaf->contents == CONTENTS_SOLID) {
+        if (bsp->loadversion == Q2_BSPVERSION ? leaf->contents & Q2_CONTENTS_SOLID : leaf->contents == CONTENTS_SOLID) {
             std::vector<winding_t *> leaf_windings = Leaf_MakeFaces(bsp, leaf, *planes);
             for (winding_t *w : leaf_windings) {
                 result->push_back(w);
@@ -522,13 +537,13 @@ MakeFaces_r(const mbsp_t *bsp, int nodenum, std::vector<plane_t> *planes, std::v
     const bsp2_dnode_t *node = &bsp->dnodes[nodenum];
 
     // go down the front side
-    plane_t front = Node_Plane(bsp, node, false);
+    const plane_t front = Node_Plane(bsp, node, false);
     planes->push_back(front);
     MakeFaces_r(bsp, node->children[0], planes, result);
     planes->pop_back();
     
     // go down the back side
-    plane_t back = Node_Plane(bsp, node, true);
+    const plane_t back = Node_Plane(bsp, node, true);
     planes->push_back(back);
     MakeFaces_r(bsp, node->children[1], planes, result);
     planes->pop_back();
@@ -568,7 +583,6 @@ Embree_TraceInit(const mbsp_t *bsp)
         
         for (int i=0; i<model->model->numfaces; i++) {
             const bsp2_dface_t *face = BSP_GetFace(bsp, model->model->firstface + i);
-            const char *texname = Face_TextureName(bsp, face);
             
             // check for TEX_NOSHADOW
             const uint64_t extended_flags = extended_texinfo_flags[face->texinfo];
@@ -581,26 +595,34 @@ Embree_TraceInit(const mbsp_t *bsp)
                 continue;
             }
             
+            const int contents = Face_Contents(bsp, face); //mxd
+
+            //mxd. Skip NODRAW faces
+            if(bsp->loadversion == Q2_BSPVERSION && (contents & Q2_SURF_NODRAW))
+                continue;
+            
             // handle glass
-            if (model->alpha.floatValue() < 1.0f) {
+            if (model->alpha.floatValue() < 1.0f 
+                || (bsp->loadversion == Q2_BSPVERSION && (contents & Q2_SURF_TRANSLUCENT))) { //mxd. Both fence and transparent textures are done using SURF_TRANS flags in Q2
                 filterfaces.push_back(face);
                 continue;
             }
             
             // fence
+            const char *texname = Face_TextureName(bsp, face);
             if (texname[0] == '{') {
                 filterfaces.push_back(face);
                 continue;
             }
             
             // handle sky
-            if (!Q_strncasecmp("sky", texname, 3)) {
+            if (/* !Q_strncasecmp("sky", texname, 3) */ bsp->loadversion == Q2_BSPVERSION ? contents & Q2_SURF_SKY : contents == CONTENTS_SKY) { //mxd
                 skyfaces.push_back(face);
                 continue;
             }
             
             // liquids
-            if (texname[0] == '*') {
+            if (/* texname[0] == '*' */ Contents_IsTranslucent(bsp, contents)) { //mxd
                 if (!isWorld) {
                     // world liquids never cast shadows; shadow casting bmodel liquids do
                     solidfaces.push_back(face);
@@ -632,7 +654,7 @@ Embree_TraceInit(const mbsp_t *bsp)
     }
     
     device = rtcNewDevice();
-    rtcDeviceSetErrorFunction(device, ErrorCallback);
+    rtcDeviceSetErrorFunction2(device, ErrorCallback, nullptr); //mxd. Changed from rtcDeviceSetErrorFunction to silence compiler warning...
     
     // log version
     const size_t ver_maj = rtcDeviceGetParameter1i(device, RTC_CONFIG_VERSION_MAJOR);

--- a/light/trace_embree.cc
+++ b/light/trace_embree.cc
@@ -597,8 +597,8 @@ Embree_TraceInit(const mbsp_t *bsp)
             
             const int contents = Face_Contents(bsp, face); //mxd
 
-            //mxd. Skip NODRAW faces
-            if(bsp->loadversion == Q2_BSPVERSION && (contents & Q2_SURF_NODRAW))
+            //mxd. Skip NODRAW faces, but not SKY ones (Q2's sky01.wal has both flags set)
+            if(bsp->loadversion == Q2_BSPVERSION && (contents & Q2_SURF_NODRAW) && !(contents & Q2_SURF_SKY))
                 continue;
             
             // handle glass


### PR DESCRIPTION
This adds support for several Quake 2 features, including area lights, palette and texture loading and transparent/sky/fence textures. Here's the list of notable changes:

Palette handling and loading: 
The palette iteslf and palette handling functions were moved to the new imglib.cc file. LoadPalette function was added. For Quake 2, it will try to load the palette from pics/colormap.pcx and replace the palette with hardcoded Quake 2 palette if that fails. For Hexen 2, it will replace the palette with hardcoded Hexen 2 palette.

External texture loading:
Most of Quake 2 source ports can use true-color textures stored in conventional image formats. Several changes were made to support that in a generic manner:
- the new drgbatexdata property was added to mbsp_t. It's structured the same way as dtexdata and consists of dmiptexlump_t followed by new rgba_miptex_t structs, followed by image data stored as RGBA bytes. A new color_rgba struct was added to simplify image data handling.
- after loading the BSP, external textures are loaded into drgbatexdata (Quake 2, currently WAL and TGA images only), or converted from dtexdata (Quake / Hexen 2) (see LoadOrConvertTextures in imglib.cc). 
- all image handling functions were changed to use rgba_miptex_t instead of miptex_t.

Surface lights:
This is not a direct port of qrad3 surface lights logic. Instead, it's a tweaked version of bouce light logic tuned to look similar to qrad3/arghrad3 surface lights (that's why there are some strange scalers here and there...). Lights setup is done in surflight.cc. 

Other notable changes:
- SetQdirFromPath() was rewritten from scratch. Instead of searching for "quake" (or "quake2" in qrad3) folder in a given path, it searches for base game folder ("ID1" / "BASEQ2" / "DATA1"), which is more likely to be named exactly that. Also, basedir property was added. It stores the path to the base game folder (like "c:/Quake/id1/") (used in Q2 texture and palette loading logic to search for images in both base game and mod folders when those differ).
- "-arghradcompat" command line option was added. It converts some arghrad light properties to their ericw-tools equivalents (added for debugging reasons, so I don't have to keep and synchronize 2 versions of the same Q2 map to compare the results with argrad3/qrad3). 
- Fixed, _project_texture: an extra row and column of pixels were drawn (most noticeable when using lores project_textures).
- Added, _project_texture: texture colors are now modulated by light color.
- Added, _project_texture: when "_project_texture" property is set and "mangle" / "_project_mangle" are not, projangle is set from "angles" property.
- .lit output is now enabled when _project_textures are used in the bsp.
- For Quake 2, cfg.rangescale now defaults to 1.0 to better match with argrad3/qrad3. 
- Warning about delay/_falloff mismatch was moved to CheckEntityFields to avoid message spam.
- Bounce/surface lights counts are now displayed.
- All compilation warnings in "light" project were fixed.
- A couple of clang-suggested optimizations were implemented.
- Some consts were added here and there.
- Some variable names in function declarations were renamed to match with corresponding implementations.