### PR TITLE
Add ability to set phong in worldspawn #267

### DIFF
--- a/include/light/light.hh
+++ b/include/light/light.hh
@@ -219,7 +219,7 @@ public:
         if (s != 0) {
             return s;
         }
-        if (phong.boolValue()) {
+        if (phong.intValue() > 0) {
             return DEFAULT_PHONG_ANGLE;
         }
         return 0;
@@ -281,6 +281,7 @@ public:
     
     /* phong */
     lockable_bool_t phongallowed;
+    lockable_vec_t phongangle;
     
     /* bounce */
     lockable_bool_t bounce;
@@ -330,6 +331,7 @@ public:
 
         /* phong */
         phongallowed {"phong", true},
+        phongangle { "phong_angle", 0}, 
 
         /* bounce */
         bounce {"bounce", false},

--- a/light/light.cc
+++ b/light/light.cc
@@ -335,6 +335,7 @@ FindModelInfo(const mbsp_t *bsp, const char *lmscaleoverride)
     /* The world always casts shadows */
     modelinfo_t *world = new modelinfo_t { bsp, &bsp->dmodels[0], lightmapscale };
     world->shadow.setFloatValue(1.0f); /* world always casts shadows */
+    world->phong_angle = cfg_static.phongangle;
     modelinfo.push_back(world);
     tracelist.push_back(world);
     


### PR DESCRIPTION
This change makes it such that if _phong_angle is set on worldspawn, phong will be used by default - this can be overridden for individual brush entities by setting _phong to -1 on that entity.