### PR TITLE
Q2BSP + QBSP

### DIFF
--- a/bsputil/bsputil.cc
+++ b/bsputil/bsputil.cc
@@ -541,7 +541,7 @@ main(int argc, char **argv)
 
     LoadBSPFile(source, &bspdata);
 
-    ConvertBSPFormat(GENERIC_BSP, &bspdata);
+    ConvertBSPFormat(GENERIC_BSP, -1, &bspdata);
 
     for (i = 0; i < argc - 1; i++) {
         if (!strcmp(argv[i], "--compare")) {
@@ -556,7 +556,7 @@ main(int argc, char **argv)
             strcpy(refbspname, argv[i]);
             DefaultExtension(refbspname, ".bsp");
             LoadBSPFile(refbspname, &refbspdata);
-            ConvertBSPFormat(GENERIC_BSP, &refbspdata);
+            ConvertBSPFormat(GENERIC_BSP, -1, &refbspdata);
 
             printf("comparing reference bsp %s with test bsp %s\n", refbspname, source);
 
@@ -570,7 +570,7 @@ main(int argc, char **argv)
                 Error("--convert requires an argument");
             }
             
-            int fmt;
+            int fmt, ident;
             if (!strcmp(argv[i], "bsp29")) {
                 fmt = BSPVERSION;
             } else if (!strcmp(argv[i], "bsp2")) {
@@ -579,11 +579,15 @@ main(int argc, char **argv)
                 fmt = BSP2RMQVERSION;
             } else if (!strcmp(argv[i], "q2bsp")) {
                 fmt = Q2_BSPVERSION;
+                ident = Q2_BSPIDENT;
+            } else if (!strcmp(argv[i], "q2bsp_qbsp")) {
+                fmt = Q2_BSPVERSION;
+                ident = Q2_QBSPIDENT;
             } else {
                 Error("Unsupported format %s", argv[i]);
             }
             
-            ConvertBSPFormat(fmt, &bspdata);
+            ConvertBSPFormat(fmt, ident, &bspdata);
             
             StripExtension(source);
             strcat(source, "-");
@@ -671,7 +675,7 @@ main(int argc, char **argv)
             bsp2_dface_t* face = BSP_GetFace(bsp, fnum);
             face->texinfo = texinfonum;
 
-            ConvertBSPFormat(bspdata.loadversion, &bspdata);            
+            ConvertBSPFormat(bspdata.loadversion, -1, &bspdata);            
 
             // Overwrite source bsp!
             WriteBSPFile(source, &bspdata);

--- a/bsputil/bsputil.cc
+++ b/bsputil/bsputil.cc
@@ -580,7 +580,7 @@ main(int argc, char **argv)
             } else if (!strcmp(argv[i], "q2bsp")) {
                 fmt = Q2_BSPVERSION;
                 ident = Q2_BSPIDENT;
-            } else if (!strcmp(argv[i], "q2bsp_qbsp")) {
+            } else if (!strcmp(argv[i], "q2bsp_qbism")) {
                 fmt = Q2_BSPVERSION;
                 ident = Q2_QBSPIDENT;
             } else {

--- a/bsputil/bsputil.cc
+++ b/bsputil/bsputil.cc
@@ -541,7 +541,7 @@ main(int argc, char **argv)
 
     LoadBSPFile(source, &bspdata);
 
-    ConvertBSPFormat(GENERIC_BSP, -1, &bspdata);
+    ConvertBSPFormat(&bspdata, &bspver_generic);
 
     for (i = 0; i < argc - 1; i++) {
         if (!strcmp(argv[i], "--compare")) {
@@ -556,7 +556,7 @@ main(int argc, char **argv)
             strcpy(refbspname, argv[i]);
             DefaultExtension(refbspname, ".bsp");
             LoadBSPFile(refbspname, &refbspdata);
-            ConvertBSPFormat(GENERIC_BSP, -1, &refbspdata);
+            ConvertBSPFormat(&refbspdata, &bspver_generic);
 
             printf("comparing reference bsp %s with test bsp %s\n", refbspname, source);
 
@@ -569,25 +569,21 @@ main(int argc, char **argv)
             if (!(i < argc - 1)) {
                 Error("--convert requires an argument");
             }
-            
-            int fmt, ident;
-            if (!strcmp(argv[i], "bsp29")) {
-                fmt = BSPVERSION;
-            } else if (!strcmp(argv[i], "bsp2")) {
-                fmt = BSP2VERSION;
-            } else if (!strcmp(argv[i], "bsp2rmq")) {
-                fmt = BSP2RMQVERSION;
-            } else if (!strcmp(argv[i], "q2bsp")) {
-                fmt = Q2_BSPVERSION;
-                ident = Q2_BSPIDENT;
-            } else if (!strcmp(argv[i], "q2bsp_qbism")) {
-                fmt = Q2_BSPVERSION;
-                ident = Q2_QBSPIDENT;
-            } else {
+
+            const bspversion_t *fmt = nullptr;
+
+            for (const bspversion_t *bspver : bspversions) {
+                if (!strcmp(argv[i], bspver->short_name)) {
+                    fmt = bspver;
+                    break;
+                }
+            }
+
+            if (!fmt) {
                 Error("Unsupported format %s", argv[i]);
             }
-            
-            ConvertBSPFormat(fmt, ident, &bspdata);
+
+            ConvertBSPFormat(&bspdata, fmt);
             
             StripExtension(source);
             strcat(source, "-");
@@ -675,7 +671,7 @@ main(int argc, char **argv)
             bsp2_dface_t* face = BSP_GetFace(bsp, fnum);
             face->texinfo = texinfonum;
 
-            ConvertBSPFormat(bspdata.loadversion, -1, &bspdata);            
+            ConvertBSPFormat(&bspdata, bspdata.loadversion);            
 
             // Overwrite source bsp!
             WriteBSPFile(source, &bspdata);

--- a/common/bspfile.cc
+++ b/common/bspfile.cc
@@ -567,6 +567,200 @@ void Q2_SwapBSPFile (q2bsp_t *bsp, qboolean todisk)
 }
 
 /*
+=============
+Q2_QBSP_SwapBSPFile
+
+Byte swaps all data in a bsp file.
+=============
+*/
+void Q2_QBSP_SwapBSPFile (q2bsp_qbsp_t *bsp, qboolean todisk)
+{
+    int                i, j;
+    q2_dmodel_t        *d;
+    
+    
+    // models
+    for (i=0 ; i<bsp->nummodels ; i++)
+    {
+        d = &bsp->dmodels[i];
+        
+        d->firstface = LittleLong (d->firstface);
+        d->numfaces = LittleLong (d->numfaces);
+        d->headnode = LittleLong (d->headnode);
+        
+        for (j=0 ; j<3 ; j++)
+        {
+            d->mins[j] = LittleFloat(d->mins[j]);
+            d->maxs[j] = LittleFloat(d->maxs[j]);
+            d->origin[j] = LittleFloat(d->origin[j]);
+        }
+    }
+    
+    //
+    // vertexes
+    //
+    for (i=0 ; i<bsp->numvertexes ; i++)
+    {
+        for (j=0 ; j<3 ; j++)
+            bsp->dvertexes[i].point[j] = LittleFloat (bsp->dvertexes[i].point[j]);
+    }
+    
+    //
+    // planes
+    //
+    for (i=0 ; i<bsp->numplanes ; i++)
+    {
+        for (j=0 ; j<3 ; j++)
+            bsp->dplanes[i].normal[j] = LittleFloat (bsp->dplanes[i].normal[j]);
+        bsp->dplanes[i].dist = LittleFloat (bsp->dplanes[i].dist);
+        bsp->dplanes[i].type = LittleLong (bsp->dplanes[i].type);
+    }
+    
+    //
+    // texinfos
+    //
+    for (i=0 ; i<bsp->numtexinfo ; i++)
+    {
+        for (j=0 ; j<4 ; j++)
+        {
+            bsp->texinfo[i].vecs[0][j] = LittleFloat(bsp->texinfo[i].vecs[0][j]);
+            bsp->texinfo[i].vecs[1][j] = LittleFloat(bsp->texinfo[i].vecs[1][j]);
+        }
+        bsp->texinfo[i].flags = LittleLong (bsp->texinfo[i].flags);
+        bsp->texinfo[i].value = LittleLong (bsp->texinfo[i].value);
+        bsp->texinfo[i].nexttexinfo = LittleLong (bsp->texinfo[i].nexttexinfo);
+    }
+    
+    //
+    // faces
+    //
+    for (i=0 ; i<bsp->numfaces ; i++)
+    {
+        bsp->dfaces[i].texinfo = LittleLong (bsp->dfaces[i].texinfo);
+        bsp->dfaces[i].planenum = LittleLong (bsp->dfaces[i].planenum);
+        bsp->dfaces[i].side = LittleLong (bsp->dfaces[i].side);
+        bsp->dfaces[i].lightofs = LittleLong (bsp->dfaces[i].lightofs);
+        bsp->dfaces[i].firstedge = LittleLong (bsp->dfaces[i].firstedge);
+        bsp->dfaces[i].numedges = LittleLong (bsp->dfaces[i].numedges);
+    }
+    
+    //
+    // nodes
+    //
+    for (i=0 ; i<bsp->numnodes ; i++)
+    {
+        bsp->dnodes[i].planenum = LittleLong (bsp->dnodes[i].planenum);
+        for (j=0 ; j<3 ; j++)
+        {
+            bsp->dnodes[i].mins[j] = LittleFloat (bsp->dnodes[i].mins[j]);
+            bsp->dnodes[i].maxs[j] = LittleFloat (bsp->dnodes[i].maxs[j]);
+        }
+        bsp->dnodes[i].children[0] = LittleLong (bsp->dnodes[i].children[0]);
+        bsp->dnodes[i].children[1] = LittleLong (bsp->dnodes[i].children[1]);
+        bsp->dnodes[i].firstface = LittleLong (bsp->dnodes[i].firstface);
+        bsp->dnodes[i].numfaces = LittleLong (bsp->dnodes[i].numfaces);
+    }
+    
+    //
+    // leafs
+    //
+    for (i=0 ; i<bsp->numleafs ; i++)
+    {
+        bsp->dleafs[i].contents = LittleLong (bsp->dleafs[i].contents);
+        bsp->dleafs[i].cluster = LittleLong (bsp->dleafs[i].cluster);
+        bsp->dleafs[i].area = LittleLong (bsp->dleafs[i].area);
+        for (j=0 ; j<3 ; j++)
+        {
+            bsp->dleafs[i].mins[j] = LittleFloat (bsp->dleafs[i].mins[j]);
+            bsp->dleafs[i].maxs[j] = LittleFloat (bsp->dleafs[i].maxs[j]);
+        }
+        
+        bsp->dleafs[i].firstleafface = LittleLong (bsp->dleafs[i].firstleafface);
+        bsp->dleafs[i].numleaffaces = LittleLong (bsp->dleafs[i].numleaffaces);
+        bsp->dleafs[i].firstleafbrush = LittleLong (bsp->dleafs[i].firstleafbrush);
+        bsp->dleafs[i].numleafbrushes = LittleLong (bsp->dleafs[i].numleafbrushes);
+    }
+    
+    //
+    // leaffaces
+    //
+    for (i=0 ; i<bsp->numleaffaces ; i++)
+        bsp->dleaffaces[i] = LittleLong (bsp->dleaffaces[i]);
+    
+    //
+    // leafbrushes
+    //
+    for (i=0 ; i<bsp->numleafbrushes ; i++)
+        bsp->dleafbrushes[i] = LittleLong (bsp->dleafbrushes[i]);
+    
+    //
+    // surfedges
+    //
+    for (i=0 ; i<bsp->numsurfedges ; i++)
+        bsp->dsurfedges[i] = LittleLong (bsp->dsurfedges[i]);
+    
+    //
+    // edges
+    //
+    for (i=0 ; i<bsp->numedges ; i++)
+    {
+        bsp->dedges[i].v[0] = LittleLong (bsp->dedges[i].v[0]);
+        bsp->dedges[i].v[1] = LittleLong (bsp->dedges[i].v[1]);
+    }
+    
+    //
+    // brushes
+    //
+    for (i=0 ; i<bsp->numbrushes ; i++)
+    {
+        bsp->dbrushes[i].firstside = LittleLong (bsp->dbrushes[i].firstside);
+        bsp->dbrushes[i].numsides = LittleLong (bsp->dbrushes[i].numsides);
+        bsp->dbrushes[i].contents = LittleLong (bsp->dbrushes[i].contents);
+    }
+    
+    //
+    // areas
+    //
+    for (i=0 ; i<bsp->numareas ; i++)
+    {
+        bsp->dareas[i].numareaportals = LittleLong (bsp->dareas[i].numareaportals);
+        bsp->dareas[i].firstareaportal = LittleLong (bsp->dareas[i].firstareaportal);
+    }
+    
+    //
+    // areasportals
+    //
+    for (i=0 ; i<bsp->numareaportals ; i++)
+    {
+        bsp->dareaportals[i].portalnum = LittleLong (bsp->dareaportals[i].portalnum);
+        bsp->dareaportals[i].otherarea = LittleLong (bsp->dareaportals[i].otherarea);
+    }
+    
+    //
+    // brushsides
+    //
+    for (i=0 ; i<bsp->numbrushsides ; i++)
+    {
+        bsp->dbrushsides[i].planenum = LittleLong (bsp->dbrushsides[i].planenum);
+        bsp->dbrushsides[i].texinfo = LittleLong (bsp->dbrushsides[i].texinfo);
+    }
+    
+    //
+    // visibility
+    //
+    if (todisk)
+        j = bsp->dvis->numclusters;
+    else
+        j = LittleLong(bsp->dvis->numclusters);
+    bsp->dvis->numclusters = LittleLong (bsp->dvis->numclusters);
+    for (i=0 ; i<j ; i++)
+    {
+        bsp->dvis->bitofs[i][0] = LittleLong (bsp->dvis->bitofs[i][0]);
+        bsp->dvis->bitofs[i][1] = LittleLong (bsp->dvis->bitofs[i][1]);
+    }
+}
+
+/*
  * =============
  * SwapBSPFile
  * Byte swaps all data in a bsp file.
@@ -576,9 +770,14 @@ static void
 SwapBSPFile(bspdata_t *bspdata, swaptype_t swap)
 {
     if (bspdata->version == Q2_BSPVERSION) {
-        q2bsp_t *bsp = &bspdata->data.q2bsp;
-        
-        Q2_SwapBSPFile(bsp, swap == TO_DISK);
+
+        if (bspdata->ident == Q2_BSPIDENT) {
+            q2bsp_t *bsp = &bspdata->data.q2bsp;
+            Q2_SwapBSPFile(bsp, swap == TO_DISK);
+        } else if (bspdata->ident == Q2_QBSPIDENT) {
+            q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
+            Q2_QBSP_SwapBSPFile(bsp, swap == TO_DISK);
+        }
         
         return;
     }
@@ -813,6 +1012,33 @@ Q2BSPtoM_Leafs(const q2_dleaf_t *dleafsq2, int numleafs) {
     return newdata;
 }
 
+static mleaf_t *
+Q2BSP_QBSPtoM_Leafs(const q2_dleaf_qbsp_t *dleafsq2, int numleafs) {
+    const q2_dleaf_qbsp_t *dleafq2 = dleafsq2;
+    mleaf_t *newdata, *mleaf;
+    int i, j;
+    
+    newdata = mleaf = (mleaf_t *)calloc(numleafs, sizeof(*mleaf));
+    
+    for (i = 0; i < numleafs; i++, dleafq2++, mleaf++) {
+        mleaf->contents = dleafq2->contents;
+        mleaf->cluster = dleafq2->cluster;
+        mleaf->area = dleafq2->area;
+        
+        for (j = 0; j < 3; j++) {
+            mleaf->mins[j] = dleafq2->mins[j];
+            mleaf->maxs[j] = dleafq2->maxs[j];
+        }
+        mleaf->firstmarksurface = dleafq2->firstleafface;
+        mleaf->nummarksurfaces = dleafq2->numleaffaces;
+        
+        mleaf->firstleafbrush = dleafq2->firstleafbrush;
+        mleaf->numleafbrushes = dleafq2->numleafbrushes;
+    }
+    
+    return newdata;
+}
+
 static q2_dleaf_t *
 MBSPtoQ2_Leafs(const mleaf_t *mleafs, int numleafs) {
     const mleaf_t *mleaf = mleafs;
@@ -889,6 +1115,28 @@ BSP2toQ2_Nodes(const bsp2_dnode_t *dnodes2, int numnodes) {
 static bsp2_dface_t *
 Q2BSPto2_Faces(const q2_dface_t *dfacesq2, int numfaces) {
     const q2_dface_t *dfaceq2 = dfacesq2;
+    bsp2_dface_t *newdata, *dface2;
+    int i, j;
+    
+    newdata = dface2 = static_cast<bsp2_dface_t *>(malloc(numfaces * sizeof(*dface2)));
+    
+    for (i = 0; i < numfaces; i++, dfaceq2++, dface2++) {
+        dface2->planenum = dfaceq2->planenum;
+        dface2->side = dfaceq2->side;
+        dface2->firstedge = dfaceq2->firstedge;
+        dface2->numedges = dfaceq2->numedges;
+        dface2->texinfo = dfaceq2->texinfo;
+        for (j = 0; j < MAXLIGHTMAPS; j++)
+            dface2->styles[j] = dfaceq2->styles[j];
+        dface2->lightofs = dfaceq2->lightofs;
+    }
+    
+    return newdata;
+}
+
+static bsp2_dface_t *
+Q2BSP_QBSPto2_Faces(const q2_dface_qbsp_t *dfacesq2, int numfaces) {
+    const q2_dface_qbsp_t *dfaceq2 = dfacesq2;
     bsp2_dface_t *newdata, *dface2;
     int i, j;
     
@@ -1415,9 +1663,37 @@ static bsp2_dnode_t *BSP2_CopyNodes(const bsp2_dnode_t *dnodes, int numnodes)
     return (bsp2_dnode_t *)CopyArray(dnodes, numnodes, sizeof(*dnodes));
 }
 
-static uint16_t *Q2BSP_CopyLeafBrushes(const uint16_t *leafbrushes, int count)
+static uint32_t *Q2BSPtoM_CopyLeafBrushes(const uint16_t *leafbrushes, int count)
 {
-    return (uint16_t *)CopyArray(leafbrushes, count, sizeof(*leafbrushes));
+    const uint16_t *leafbrush = leafbrushes;
+    uint32_t *newdata, *leafbrushes2;
+    int i;
+
+    newdata = leafbrushes2 = static_cast<uint32_t *>(malloc(count * sizeof(*leafbrushes2)));
+
+    for (i = 0; i < count; i++, leafbrush++, leafbrushes2++)
+        *leafbrushes2 = *leafbrush;
+
+    return newdata;
+}
+
+static uint16_t *MBSPtoQ2_CopyLeafBrushes(const uint32_t *leafbrushes, int count)
+{
+    const uint32_t *leafbrush = leafbrushes;
+    uint16_t *newdata, *leafbrushes2;
+    int i;
+
+    newdata = leafbrushes2 = static_cast<uint16_t *>(malloc(count * sizeof(*leafbrushes2)));
+
+    for (i = 0; i < count; i++, leafbrush++, leafbrushes2++)
+        *leafbrushes2 = *leafbrush;
+
+    return newdata;
+}
+
+static uint32_t *Q2BSP_QBSP_CopyLeafBrushes(const uint32_t *leafbrushes, int count)
+{
+    return (uint32_t *)CopyArray(leafbrushes, count, sizeof(*leafbrushes));
 }
 
 static darea_t *Q2BSP_CopyAreas(const darea_t *areas, int count)
@@ -1435,9 +1711,41 @@ static dbrush_t *Q2BSP_CopyBrushes(const dbrush_t *brushes, int count)
     return (dbrush_t *)CopyArray(brushes, count, sizeof(*brushes));
 }
 
-static dbrushside_t *Q2BSP_CopyBrushSides(const dbrushside_t *dbrushsides, int count)
+static q2_dbrushside_qbsp_t *Q2BSPtoM_CopyBrushSides(const dbrushside_t *dbrushsides, int count)
 {
-    return (dbrushside_t *)CopyArray(dbrushsides, count, sizeof(*dbrushsides));
+    const dbrushside_t *brushside = dbrushsides;
+    q2_dbrushside_qbsp_t *newdata, *brushsides2;
+    int i;
+
+    newdata = brushsides2 = static_cast<q2_dbrushside_qbsp_t *>(malloc(count * sizeof(*brushsides2)));
+
+    for (i = 0; i < count; i++, brushside++, brushsides2++) {
+        brushsides2->planenum = brushside->planenum;
+        brushsides2->texinfo = brushside->texinfo;
+    }
+
+    return newdata;
+}
+
+static q2_dbrushside_qbsp_t *Q2BSP_QBSP_CopyBrushSides(const q2_dbrushside_qbsp_t *brushsides, int count)
+{
+    return (q2_dbrushside_qbsp_t *)CopyArray(brushsides, count, sizeof(*brushsides));
+}
+
+static dbrushside_t *MBSPtoQ2_CopyBrushSides(const q2_dbrushside_qbsp_t *dbrushsides, int count)
+{
+    const q2_dbrushside_qbsp_t *brushside = dbrushsides;
+    dbrushside_t *newdata, *brushsides2;
+    int i;
+
+    newdata = brushsides2 = static_cast<dbrushside_t *>(malloc(count * sizeof(*brushsides2)));
+
+    for (i = 0; i < count; i++, brushside++, brushsides2++) {
+        brushsides2->planenum = brushside->planenum;
+        brushsides2->texinfo = brushside->texinfo;
+    }
+
+    return newdata;
 }
 
 
@@ -1622,59 +1930,115 @@ ConvertBSPFormat(int32_t version, bspdata_t *bspdata)
     }
     
     if (bspdata->version == Q2_BSPVERSION && version == GENERIC_BSP) {
-        const q2bsp_t *q2bsp = &bspdata->data.q2bsp;
-        mbsp_t *mbsp = &bspdata->data.mbsp;
+        if (bspdata->ident == Q2_BSPIDENT) {
+            const q2bsp_t *q2bsp = &bspdata->data.q2bsp;
+            mbsp_t *mbsp = &bspdata->data.mbsp;
         
-        memset(mbsp, 0, sizeof(*mbsp));
+            memset(mbsp, 0, sizeof(*mbsp));
         
-        // copy counts
-        mbsp->nummodels = q2bsp->nummodels;
-        mbsp->visdatasize = q2bsp->visdatasize;
-        mbsp->lightdatasize = q2bsp->lightdatasize;
-        mbsp->entdatasize = q2bsp->entdatasize;
-        mbsp->numleafs = q2bsp->numleafs;
-        mbsp->numplanes = q2bsp->numplanes;
-        mbsp->numvertexes = q2bsp->numvertexes;
-        mbsp->numnodes = q2bsp->numnodes;
-        mbsp->numtexinfo = q2bsp->numtexinfo;
-        mbsp->numfaces = q2bsp->numfaces;
-        mbsp->numedges = q2bsp->numedges;
-        mbsp->numleaffaces = q2bsp->numleaffaces;
-        mbsp->numleafbrushes = q2bsp->numleafbrushes;
-        mbsp->numsurfedges = q2bsp->numsurfedges;
-        mbsp->numareas = q2bsp->numareas;
-        mbsp->numareaportals = q2bsp->numareaportals;
-        mbsp->numbrushes = q2bsp->numbrushes;
-        mbsp->numbrushsides = q2bsp->numbrushsides;
+            // copy counts
+            mbsp->nummodels = q2bsp->nummodels;
+            mbsp->visdatasize = q2bsp->visdatasize;
+            mbsp->lightdatasize = q2bsp->lightdatasize;
+            mbsp->entdatasize = q2bsp->entdatasize;
+            mbsp->numleafs = q2bsp->numleafs;
+            mbsp->numplanes = q2bsp->numplanes;
+            mbsp->numvertexes = q2bsp->numvertexes;
+            mbsp->numnodes = q2bsp->numnodes;
+            mbsp->numtexinfo = q2bsp->numtexinfo;
+            mbsp->numfaces = q2bsp->numfaces;
+            mbsp->numedges = q2bsp->numedges;
+            mbsp->numleaffaces = q2bsp->numleaffaces;
+            mbsp->numleafbrushes = q2bsp->numleafbrushes;
+            mbsp->numsurfedges = q2bsp->numsurfedges;
+            mbsp->numareas = q2bsp->numareas;
+            mbsp->numareaportals = q2bsp->numareaportals;
+            mbsp->numbrushes = q2bsp->numbrushes;
+            mbsp->numbrushsides = q2bsp->numbrushsides;
         
-        // copy or convert data
-        mbsp->dmodels = Q2BSPtoM_Models(q2bsp->dmodels, q2bsp->nummodels);
-        mbsp->dvisdata = (uint8_t *)CopyArray(q2bsp->dvis, q2bsp->visdatasize, 1);
-        mbsp->dlightdata = BSP29_CopyLightData(q2bsp->dlightdata, q2bsp->lightdatasize);
-        mbsp->dentdata = BSP29_CopyEntData(q2bsp->dentdata, q2bsp->entdatasize);
-        mbsp->dleafs = Q2BSPtoM_Leafs(q2bsp->dleafs, q2bsp->numleafs);
-        mbsp->dplanes = BSP29_CopyPlanes(q2bsp->dplanes, q2bsp->numplanes);
-        mbsp->dvertexes = BSP29_CopyVertexes(q2bsp->dvertexes, q2bsp->numvertexes);
-        mbsp->dnodes = Q2BSPto2_Nodes(q2bsp->dnodes, q2bsp->numnodes);
-        mbsp->texinfo = Q2BSPtoM_Texinfo(q2bsp->texinfo, q2bsp->numtexinfo);
-        mbsp->dfaces = Q2BSPto2_Faces(q2bsp->dfaces, q2bsp->numfaces);
-        mbsp->dedges = BSP29to2_Edges(q2bsp->dedges, q2bsp->numedges);
-        mbsp->dleaffaces = BSP29to2_Marksurfaces(q2bsp->dleaffaces, q2bsp->numleaffaces);
-        mbsp->dleafbrushes = Q2BSP_CopyLeafBrushes(q2bsp->dleafbrushes, q2bsp->numleafbrushes);
-        mbsp->dsurfedges = BSP29_CopySurfedges(q2bsp->dsurfedges, q2bsp->numsurfedges);
+            // copy or convert data
+            mbsp->dmodels = Q2BSPtoM_Models(q2bsp->dmodels, q2bsp->nummodels);
+            mbsp->dvisdata = (uint8_t *)CopyArray(q2bsp->dvis, q2bsp->visdatasize, 1);
+            mbsp->dlightdata = BSP29_CopyLightData(q2bsp->dlightdata, q2bsp->lightdatasize);
+            mbsp->dentdata = BSP29_CopyEntData(q2bsp->dentdata, q2bsp->entdatasize);
+            mbsp->dleafs = Q2BSPtoM_Leafs(q2bsp->dleafs, q2bsp->numleafs);
+            mbsp->dplanes = BSP29_CopyPlanes(q2bsp->dplanes, q2bsp->numplanes);
+            mbsp->dvertexes = BSP29_CopyVertexes(q2bsp->dvertexes, q2bsp->numvertexes);
+            mbsp->dnodes = Q2BSPto2_Nodes(q2bsp->dnodes, q2bsp->numnodes);
+            mbsp->texinfo = Q2BSPtoM_Texinfo(q2bsp->texinfo, q2bsp->numtexinfo);
+            mbsp->dfaces = Q2BSPto2_Faces(q2bsp->dfaces, q2bsp->numfaces);
+            mbsp->dedges = BSP29to2_Edges(q2bsp->dedges, q2bsp->numedges);
+            mbsp->dleaffaces = BSP29to2_Marksurfaces(q2bsp->dleaffaces, q2bsp->numleaffaces);
+            mbsp->dleafbrushes = Q2BSPtoM_CopyLeafBrushes(q2bsp->dleafbrushes, q2bsp->numleafbrushes);
+            mbsp->dsurfedges = BSP29_CopySurfedges(q2bsp->dsurfedges, q2bsp->numsurfedges);
         
-        mbsp->dareas = Q2BSP_CopyAreas(q2bsp->dareas, q2bsp->numareas);
-        mbsp->dareaportals = Q2BSP_CopyAreaPortals(q2bsp->dareaportals, q2bsp->numareaportals);
+            mbsp->dareas = Q2BSP_CopyAreas(q2bsp->dareas, q2bsp->numareas);
+            mbsp->dareaportals = Q2BSP_CopyAreaPortals(q2bsp->dareaportals, q2bsp->numareaportals);
         
-        mbsp->dbrushes = Q2BSP_CopyBrushes(q2bsp->dbrushes, q2bsp->numbrushes);
-        mbsp->dbrushsides = Q2BSP_CopyBrushSides(q2bsp->dbrushsides, q2bsp->numbrushsides);
+            mbsp->dbrushes = Q2BSP_CopyBrushes(q2bsp->dbrushes, q2bsp->numbrushes);
+            mbsp->dbrushsides = Q2BSPtoM_CopyBrushSides(q2bsp->dbrushsides, q2bsp->numbrushsides);
         
-        /* Free old data */
-        FreeQ2BSP((q2bsp_t *)q2bsp);
+            /* Free old data */
+            FreeQ2BSP((q2bsp_t *)q2bsp);
         
-        /* Conversion complete! */
-        mbsp->loadversion = bspdata->version;
-        bspdata->version = version;
+            /* Conversion complete! */
+            mbsp->loadversion = bspdata->version;
+            bspdata->version = version;
+        } else if (bspdata->ident == Q2_QBSPIDENT) {
+            const q2bsp_qbsp_t *q2bsp = &bspdata->data.q2bsp_qbsp;
+            mbsp_t *mbsp = &bspdata->data.mbsp;
+        
+            memset(mbsp, 0, sizeof(*mbsp));
+        
+            // copy counts
+            mbsp->nummodels = q2bsp->nummodels;
+            mbsp->visdatasize = q2bsp->visdatasize;
+            mbsp->lightdatasize = q2bsp->lightdatasize;
+            mbsp->entdatasize = q2bsp->entdatasize;
+            mbsp->numleafs = q2bsp->numleafs;
+            mbsp->numplanes = q2bsp->numplanes;
+            mbsp->numvertexes = q2bsp->numvertexes;
+            mbsp->numnodes = q2bsp->numnodes;
+            mbsp->numtexinfo = q2bsp->numtexinfo;
+            mbsp->numfaces = q2bsp->numfaces;
+            mbsp->numedges = q2bsp->numedges;
+            mbsp->numleaffaces = q2bsp->numleaffaces;
+            mbsp->numleafbrushes = q2bsp->numleafbrushes;
+            mbsp->numsurfedges = q2bsp->numsurfedges;
+            mbsp->numareas = q2bsp->numareas;
+            mbsp->numareaportals = q2bsp->numareaportals;
+            mbsp->numbrushes = q2bsp->numbrushes;
+            mbsp->numbrushsides = q2bsp->numbrushsides;
+        
+            // copy or convert data
+            mbsp->dmodels = Q2BSPtoM_Models(q2bsp->dmodels, q2bsp->nummodels);
+            mbsp->dvisdata = (uint8_t *)CopyArray(q2bsp->dvis, q2bsp->visdatasize, 1);
+            mbsp->dlightdata = BSP29_CopyLightData(q2bsp->dlightdata, q2bsp->lightdatasize);
+            mbsp->dentdata = BSP29_CopyEntData(q2bsp->dentdata, q2bsp->entdatasize);
+            mbsp->dleafs = Q2BSP_QBSPtoM_Leafs(q2bsp->dleafs, q2bsp->numleafs);
+            mbsp->dplanes = BSP29_CopyPlanes(q2bsp->dplanes, q2bsp->numplanes);
+            mbsp->dvertexes = BSP29_CopyVertexes(q2bsp->dvertexes, q2bsp->numvertexes);
+            mbsp->dnodes = BSP2_CopyNodes(q2bsp->dnodes, q2bsp->numnodes);
+            mbsp->texinfo = Q2BSPtoM_Texinfo(q2bsp->texinfo, q2bsp->numtexinfo);
+            mbsp->dfaces = Q2BSP_QBSPto2_Faces(q2bsp->dfaces, q2bsp->numfaces);
+            mbsp->dedges = BSP2_CopyEdges(q2bsp->dedges, q2bsp->numedges);
+            mbsp->dleaffaces = BSP2_CopyMarksurfaces(q2bsp->dleaffaces, q2bsp->numleaffaces);
+            mbsp->dleafbrushes = Q2BSP_QBSP_CopyLeafBrushes(q2bsp->dleafbrushes, q2bsp->numleafbrushes);
+            mbsp->dsurfedges = BSP29_CopySurfedges(q2bsp->dsurfedges, q2bsp->numsurfedges);
+        
+            mbsp->dareas = Q2BSP_CopyAreas(q2bsp->dareas, q2bsp->numareas);
+            mbsp->dareaportals = Q2BSP_CopyAreaPortals(q2bsp->dareaportals, q2bsp->numareaportals);
+        
+            mbsp->dbrushes = Q2BSP_CopyBrushes(q2bsp->dbrushes, q2bsp->numbrushes);
+            mbsp->dbrushsides = Q2BSP_QBSP_CopyBrushSides(q2bsp->dbrushsides, q2bsp->numbrushsides);
+        
+            /* Free old data */
+            FreeQ2BSP((q2bsp_t *)q2bsp);
+        
+            /* Conversion complete! */
+            mbsp->loadversion = bspdata->version;
+            bspdata->version = version;
+        }
         
         return;
     }
@@ -1869,14 +2233,14 @@ ConvertBSPFormat(int32_t version, bspdata_t *bspdata)
         q2bsp->dfaces = BSP2toQ2_Faces(mbsp->dfaces, mbsp->numfaces);
         q2bsp->dedges = BSP2to29_Edges(mbsp->dedges, mbsp->numedges);
         q2bsp->dleaffaces = BSP2to29_Marksurfaces(mbsp->dleaffaces, mbsp->numleaffaces);
-        q2bsp->dleafbrushes = Q2BSP_CopyLeafBrushes(mbsp->dleafbrushes, mbsp->numleafbrushes);
+        q2bsp->dleafbrushes = MBSPtoQ2_CopyLeafBrushes(mbsp->dleafbrushes, mbsp->numleafbrushes);
         q2bsp->dsurfedges = BSP29_CopySurfedges(mbsp->dsurfedges, mbsp->numsurfedges);
         
         q2bsp->dareas = Q2BSP_CopyAreas(mbsp->dareas, mbsp->numareas);
         q2bsp->dareaportals = Q2BSP_CopyAreaPortals(mbsp->dareaportals, mbsp->numareaportals);
         
         q2bsp->dbrushes = Q2BSP_CopyBrushes(mbsp->dbrushes, mbsp->numbrushes);
-        q2bsp->dbrushsides = Q2BSP_CopyBrushSides(mbsp->dbrushsides, mbsp->numbrushsides);
+        q2bsp->dbrushsides = MBSPtoQ2_CopyBrushSides(mbsp->dbrushsides, mbsp->numbrushsides);
         
         /* Free old data */
         FreeMBSP((mbsp_t *)mbsp);
@@ -2082,6 +2446,28 @@ const lumpspec_t lumpspec_q2bsp[] = {
     { "areaportals",  sizeof(dareaportal_t)     },
 };
 
+const lumpspec_t lumpspec_q2bsp_qbsp[] = {
+    { "entities",     sizeof(char)              },
+    { "planes",       sizeof(dplane_t)          },
+    { "vertexes",     sizeof(dvertex_t)         },
+    { "visibility",   sizeof(uint8_t)              },
+    { "nodes",        sizeof(q2_dnode_qbsp_t)        },
+    { "texinfos",     sizeof(q2_texinfo_t)      },
+    { "faces",        sizeof(q2_dface_qbsp_t)        },
+    { "lighting",     sizeof(uint8_t)              },
+    { "leafs",        sizeof(q2_dleaf_qbsp_t)        },
+    { "leaffaces",    sizeof(uint32_t)          },
+    { "leafbrushes",  sizeof(uint32_t)          },
+    { "edges",        sizeof(q2_dedge_qbsp_t)     },
+    { "surfedges",    sizeof(int32_t)           },
+    { "models",       sizeof(q2_dmodel_t)       },
+    { "brushes",      sizeof(dbrush_t)          },
+    { "brushsides",   sizeof(q2_dbrushside_qbsp_t)      },
+    { "pop",          sizeof(uint8_t)              },
+    { "areas",        sizeof(darea_t)           },
+    { "areaportals",  sizeof(dareaportal_t)     },
+};
+
 static int
 CopyLump(const dheader_t *header, int lumpnum, void *destptr)
 {
@@ -2172,7 +2558,13 @@ Q2_CopyLump(const q2_dheader_t *header, int lumpnum, void *destptr)
     
     switch (header->version) {
         case Q2_BSPVERSION:
-            lumpspec = &lumpspec_q2bsp[lumpnum];
+            if (header->ident == Q2_BSPIDENT) {
+                lumpspec = &lumpspec_q2bsp[lumpnum];
+            } else if (header->ident == Q2_QBSPIDENT) {
+                lumpspec = &lumpspec_q2bsp_qbsp[lumpnum];
+            } else {
+               Error("Unsupported Q2BSP ident: %d", header->ident);
+            }
             break;
         default:
             Error("Unsupported BSP version: %d", header->version);
@@ -2288,13 +2680,18 @@ LoadBSPFile(char *filename, bspdata_t *bspdata)
     lump_t *lumps;
 
     /* check for IBSP */
-    if (LittleLong(((int *)file_data)[0]) == Q2_BSPIDENT) {
+    int32_t ident = LittleLong(((int *)file_data)[0]);
+
+    if (ident == Q2_BSPIDENT ||
+        ident == Q2_QBSPIDENT) {
         q2_dheader_t *q2header = (q2_dheader_t *)file_data;
         q2header->version = LittleLong(q2header->version);
         
         numlumps = Q2_HEADER_LUMPS;
         version = q2header->version;
         lumps = q2header->lumps;
+
+        bspdata->ident = ident;
     } else {
         dheader_t *q1header = (dheader_t *)file_data;
         q1header->version = LittleLong(q1header->version);
@@ -2302,6 +2699,9 @@ LoadBSPFile(char *filename, bspdata_t *bspdata)
         numlumps = BSP_LUMPS;
         version = q1header->version;
         lumps = q1header->lumps;
+
+        // not useful for Q1BSP, but we'll initialize it to -1
+        bspdata->ident = -1;
     }
     
     bspdata->loadversion = version;
@@ -2317,43 +2717,74 @@ LoadBSPFile(char *filename, bspdata_t *bspdata)
         lumps[i].filelen = LittleLong(lumps[i].filelen);
     }
 
-    if (isHexen2((dheader_t *)file_data))
-    {
-            logprint("BSP appears to be from hexen2\n");
-            bspdata->hullcount = MAX_MAP_HULLS_H2;
-    }
-    else
-            bspdata->hullcount = MAX_MAP_HULLS_Q1;
-
     /* copy the data */
     if (version == Q2_BSPVERSION) {
         q2_dheader_t *header = (q2_dheader_t *)file_data;
-        q2bsp_t *bsp = &bspdata->data.q2bsp;
-        
-        memset(bsp, 0, sizeof(*bsp));
+
         bspdata->version = header->version;
+
+        if (header->ident == Q2_BSPIDENT) {
+            q2bsp_t *bsp = &bspdata->data.q2bsp;
+
+            memset(bsp, 0, sizeof(*bsp));
+
+            bsp->nummodels = Q2_CopyLump (header, Q2_LUMP_MODELS, &bsp->dmodels);
+            bsp->numvertexes = Q2_CopyLump (header, Q2_LUMP_VERTEXES, &bsp->dvertexes);
+            bsp->numplanes = Q2_CopyLump (header, Q2_LUMP_PLANES, &bsp->dplanes);
+            bsp->numleafs = Q2_CopyLump (header, Q2_LUMP_LEAFS, &bsp->dleafs);
+            bsp->numnodes = Q2_CopyLump (header, Q2_LUMP_NODES, &bsp->dnodes);
+            bsp->numtexinfo = Q2_CopyLump (header, Q2_LUMP_TEXINFO, &bsp->texinfo);
+            bsp->numfaces = Q2_CopyLump (header, Q2_LUMP_FACES, &bsp->dfaces);
+            bsp->numleaffaces = Q2_CopyLump (header, Q2_LUMP_LEAFFACES, &bsp->dleaffaces);
+            bsp->numleafbrushes = Q2_CopyLump (header, Q2_LUMP_LEAFBRUSHES, &bsp->dleafbrushes);
+            bsp->numsurfedges = Q2_CopyLump (header, Q2_LUMP_SURFEDGES, &bsp->dsurfedges);
+            bsp->numedges = Q2_CopyLump (header, Q2_LUMP_EDGES, &bsp->dedges);
+            bsp->numbrushes = Q2_CopyLump (header, Q2_LUMP_BRUSHES, &bsp->dbrushes);
+            bsp->numbrushsides = Q2_CopyLump (header, Q2_LUMP_BRUSHSIDES, &bsp->dbrushsides);
+            bsp->numareas = Q2_CopyLump (header, Q2_LUMP_AREAS, &bsp->dareas);
+            bsp->numareaportals = Q2_CopyLump (header, Q2_LUMP_AREAPORTALS, &bsp->dareaportals);
         
-        bsp->nummodels = Q2_CopyLump (header, Q2_LUMP_MODELS, &bsp->dmodels);
-        bsp->numvertexes = Q2_CopyLump (header, Q2_LUMP_VERTEXES, &bsp->dvertexes);
-        bsp->numplanes = Q2_CopyLump (header, Q2_LUMP_PLANES, &bsp->dplanes);
-        bsp->numleafs = Q2_CopyLump (header, Q2_LUMP_LEAFS, &bsp->dleafs);
-        bsp->numnodes = Q2_CopyLump (header, Q2_LUMP_NODES, &bsp->dnodes);
-        bsp->numtexinfo = Q2_CopyLump (header, Q2_LUMP_TEXINFO, &bsp->texinfo);
-        bsp->numfaces = Q2_CopyLump (header, Q2_LUMP_FACES, &bsp->dfaces);
-        bsp->numleaffaces = Q2_CopyLump (header, Q2_LUMP_LEAFFACES, &bsp->dleaffaces);
-        bsp->numleafbrushes = Q2_CopyLump (header, Q2_LUMP_LEAFBRUSHES, &bsp->dleafbrushes);
-        bsp->numsurfedges = Q2_CopyLump (header, Q2_LUMP_SURFEDGES, &bsp->dsurfedges);
-        bsp->numedges = Q2_CopyLump (header, Q2_LUMP_EDGES, &bsp->dedges);
-        bsp->numbrushes = Q2_CopyLump (header, Q2_LUMP_BRUSHES, &bsp->dbrushes);
-        bsp->numbrushsides = Q2_CopyLump (header, Q2_LUMP_BRUSHSIDES, &bsp->dbrushsides);
-        bsp->numareas = Q2_CopyLump (header, Q2_LUMP_AREAS, &bsp->dareas);
-        bsp->numareaportals = Q2_CopyLump (header, Q2_LUMP_AREAPORTALS, &bsp->dareaportals);
+            bsp->visdatasize = Q2_CopyLump (header, Q2_LUMP_VISIBILITY, &bsp->dvis);
+            bsp->lightdatasize = Q2_CopyLump (header, Q2_LUMP_LIGHTING, &bsp->dlightdata);
+            bsp->entdatasize = Q2_CopyLump (header, Q2_LUMP_ENTITIES, &bsp->dentdata);
         
-        bsp->visdatasize = Q2_CopyLump (header, Q2_LUMP_VISIBILITY, &bsp->dvis);
-        bsp->lightdatasize = Q2_CopyLump (header, Q2_LUMP_LIGHTING, &bsp->dlightdata);
-        bsp->entdatasize = Q2_CopyLump (header, Q2_LUMP_ENTITIES, &bsp->dentdata);
+          Q2_CopyLump (header, Q2_LUMP_POP, &bsp->dpop);
+        } else {
+
+            logprint("BSP appears to be QBSP\n");
+            q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
+
+            memset(bsp, 0, sizeof(*bsp));
+
+            bsp->nummodels = Q2_CopyLump (header, Q2_LUMP_MODELS, &bsp->dmodels);
+            bsp->numvertexes = Q2_CopyLump (header, Q2_LUMP_VERTEXES, &bsp->dvertexes);
+            bsp->numplanes = Q2_CopyLump (header, Q2_LUMP_PLANES, &bsp->dplanes);
+            bsp->numleafs = Q2_CopyLump (header, Q2_LUMP_LEAFS, &bsp->dleafs);
+            bsp->numnodes = Q2_CopyLump (header, Q2_LUMP_NODES, &bsp->dnodes);
+            bsp->numtexinfo = Q2_CopyLump (header, Q2_LUMP_TEXINFO, &bsp->texinfo);
+            bsp->numfaces = Q2_CopyLump (header, Q2_LUMP_FACES, &bsp->dfaces);
+            bsp->numleaffaces = Q2_CopyLump (header, Q2_LUMP_LEAFFACES, &bsp->dleaffaces);
+            bsp->numleafbrushes = Q2_CopyLump (header, Q2_LUMP_LEAFBRUSHES, &bsp->dleafbrushes);
+            bsp->numsurfedges = Q2_CopyLump (header, Q2_LUMP_SURFEDGES, &bsp->dsurfedges);
+            bsp->numedges = Q2_CopyLump (header, Q2_LUMP_EDGES, &bsp->dedges);
+            bsp->numbrushes = Q2_CopyLump (header, Q2_LUMP_BRUSHES, &bsp->dbrushes);
+            bsp->numbrushsides = Q2_CopyLump (header, Q2_LUMP_BRUSHSIDES, &bsp->dbrushsides);
+            bsp->numareas = Q2_CopyLump (header, Q2_LUMP_AREAS, &bsp->dareas);
+            bsp->numareaportals = Q2_CopyLump (header, Q2_LUMP_AREAPORTALS, &bsp->dareaportals);
         
-        Q2_CopyLump (header, Q2_LUMP_POP, &bsp->dpop);
+            bsp->visdatasize = Q2_CopyLump (header, Q2_LUMP_VISIBILITY, &bsp->dvis);
+            bsp->lightdatasize = Q2_CopyLump (header, Q2_LUMP_LIGHTING, &bsp->dlightdata);
+            bsp->entdatasize = Q2_CopyLump (header, Q2_LUMP_ENTITIES, &bsp->dentdata);
+        
+           Q2_CopyLump (header, Q2_LUMP_POP, &bsp->dpop);
+        }
+    } else {
+        // Only Q1-like maps need hullcount
+        if (isHexen2((dheader_t *)file_data)) {
+            logprint("BSP appears to be from hexen2\n");
+            bspdata->hullcount = MAX_MAP_HULLS_H2;
+        } else
+            bspdata->hullcount = MAX_MAP_HULLS_Q1;
     }
     
     if (version == BSPVERSION || version == BSPHLVERSION) {
@@ -2378,9 +2809,7 @@ LoadBSPFile(char *filename, bspdata_t *bspdata)
         bsp->visdatasize = CopyLump(header, LUMP_VISIBILITY, &bsp->dvisdata);
         bsp->lightdatasize = CopyLump(header, LUMP_LIGHTING, &bsp->dlightdata);
         bsp->entdatasize = CopyLump(header, LUMP_ENTITIES, &bsp->dentdata);
-    }
-
-    if (version == BSP2RMQVERSION) {
+    } else if (version == BSP2RMQVERSION) {
         dheader_t *header = (dheader_t *)file_data;
         bsp2rmq_t *bsp = &bspdata->data.bsp2rmq;
 
@@ -2402,9 +2831,7 @@ LoadBSPFile(char *filename, bspdata_t *bspdata)
         bsp->visdatasize = CopyLump(header, LUMP_VISIBILITY, &bsp->dvisdata);
         bsp->lightdatasize = CopyLump(header, LUMP_LIGHTING, &bsp->dlightdata);
         bsp->entdatasize = CopyLump(header, LUMP_ENTITIES, &bsp->dentdata);
-    }
-
-    if (version == BSP2VERSION) {
+    } else if (version == BSP2VERSION) {
         dheader_t *header = (dheader_t *)file_data;
         bsp2_t *bsp = &bspdata->data.bsp2;
 
@@ -2503,7 +2930,14 @@ AddLump(bspfile_t *bspfile, int lumpnum, const void *data, int count)
         size = lumpspec_bsp2[lumpnum].size * count;
         break;
     case Q2_BSPVERSION:
-        size = lumpspec_q2bsp[lumpnum].size * count;
+        if (bspfile->q2header.ident == Q2_BSPIDENT) {
+            size = lumpspec_q2bsp[lumpnum].size * count;
+        } else if (bspfile->q2header.ident == Q2_QBSPIDENT) {
+            size = lumpspec_q2bsp_qbsp[lumpnum].size * count;
+        } else {
+            Error("Unsupported Q2BSP ident: %d", LittleLong(bspfile->q2header.ident));
+            throw; //mxd. Fixes "Uninitialized variable" warning
+        }
         q2 = true;
         break;
     default:
@@ -2748,29 +3182,57 @@ PrintBSPFileSizes(const bspdata_t *bspdata)
     int numtextures = 0;
 
     if (bspdata->version == Q2_BSPVERSION) {
-        const q2bsp_t *bsp = &bspdata->data.q2bsp;
-        const lumpspec_t *lumpspec = lumpspec_q2bsp;
+        if (bspdata->ident == Q2_BSPIDENT) {
+            const q2bsp_t *bsp = &bspdata->data.q2bsp;
+            const lumpspec_t *lumpspec = lumpspec_q2bsp;
         
-        logprint("%7i %-12s\n", bsp->nummodels, "models");
+            logprint("%7i %-12s\n", bsp->nummodels, "models");
         
-        PrintLumpSize(lumpspec, Q2_LUMP_PLANES, bsp->numplanes);
-        PrintLumpSize(lumpspec, Q2_LUMP_VERTEXES, bsp->numvertexes);
-        PrintLumpSize(lumpspec, Q2_LUMP_NODES, bsp->numnodes);
-        PrintLumpSize(lumpspec, Q2_LUMP_TEXINFO, bsp->numtexinfo);
-        PrintLumpSize(lumpspec, Q2_LUMP_FACES, bsp->numfaces);
-        PrintLumpSize(lumpspec, Q2_LUMP_LEAFS, bsp->numleafs);
-        PrintLumpSize(lumpspec, Q2_LUMP_LEAFFACES, bsp->numleaffaces);
-        PrintLumpSize(lumpspec, Q2_LUMP_LEAFBRUSHES, bsp->numleafbrushes);
-        PrintLumpSize(lumpspec, Q2_LUMP_EDGES, bsp->numedges);
-        PrintLumpSize(lumpspec, Q2_LUMP_SURFEDGES, bsp->numsurfedges);
-        PrintLumpSize(lumpspec, Q2_LUMP_BRUSHES, bsp->numbrushes);
-        PrintLumpSize(lumpspec, Q2_LUMP_BRUSHSIDES, bsp->numbrushsides);
-        PrintLumpSize(lumpspec, Q2_LUMP_AREAS, bsp->numareas);
-        PrintLumpSize(lumpspec, Q2_LUMP_AREAPORTALS, bsp->numareaportals);
+            PrintLumpSize(lumpspec, Q2_LUMP_PLANES, bsp->numplanes);
+            PrintLumpSize(lumpspec, Q2_LUMP_VERTEXES, bsp->numvertexes);
+            PrintLumpSize(lumpspec, Q2_LUMP_NODES, bsp->numnodes);
+            PrintLumpSize(lumpspec, Q2_LUMP_TEXINFO, bsp->numtexinfo);
+            PrintLumpSize(lumpspec, Q2_LUMP_FACES, bsp->numfaces);
+            PrintLumpSize(lumpspec, Q2_LUMP_LEAFS, bsp->numleafs);
+            PrintLumpSize(lumpspec, Q2_LUMP_LEAFFACES, bsp->numleaffaces);
+            PrintLumpSize(lumpspec, Q2_LUMP_LEAFBRUSHES, bsp->numleafbrushes);
+            PrintLumpSize(lumpspec, Q2_LUMP_EDGES, bsp->numedges);
+            PrintLumpSize(lumpspec, Q2_LUMP_SURFEDGES, bsp->numsurfedges);
+            PrintLumpSize(lumpspec, Q2_LUMP_BRUSHES, bsp->numbrushes);
+            PrintLumpSize(lumpspec, Q2_LUMP_BRUSHSIDES, bsp->numbrushsides);
+            PrintLumpSize(lumpspec, Q2_LUMP_AREAS, bsp->numareas);
+            PrintLumpSize(lumpspec, Q2_LUMP_AREAPORTALS, bsp->numareaportals);
         
-        logprint("%7s %-12s %10i\n", "", "lightdata", bsp->lightdatasize);
-        logprint("%7s %-12s %10i\n", "", "visdata", bsp->visdatasize);
-        logprint("%7s %-12s %10i\n", "", "entdata", bsp->entdatasize);
+            logprint("%7s %-12s %10i\n", "", "lightdata", bsp->lightdatasize);
+            logprint("%7s %-12s %10i\n", "", "visdata", bsp->visdatasize);
+            logprint("%7s %-12s %10i\n", "", "entdata", bsp->entdatasize);
+        } else if (bspdata->ident == Q2_QBSPIDENT) {
+            const q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
+            const lumpspec_t *lumpspec = lumpspec_q2bsp_qbsp;
+        
+            logprint("%7i %-12s\n", bsp->nummodels, "models");
+        
+            PrintLumpSize(lumpspec, Q2_LUMP_PLANES, bsp->numplanes);
+            PrintLumpSize(lumpspec, Q2_LUMP_VERTEXES, bsp->numvertexes);
+            PrintLumpSize(lumpspec, Q2_LUMP_NODES, bsp->numnodes);
+            PrintLumpSize(lumpspec, Q2_LUMP_TEXINFO, bsp->numtexinfo);
+            PrintLumpSize(lumpspec, Q2_LUMP_FACES, bsp->numfaces);
+            PrintLumpSize(lumpspec, Q2_LUMP_LEAFS, bsp->numleafs);
+            PrintLumpSize(lumpspec, Q2_LUMP_LEAFFACES, bsp->numleaffaces);
+            PrintLumpSize(lumpspec, Q2_LUMP_LEAFBRUSHES, bsp->numleafbrushes);
+            PrintLumpSize(lumpspec, Q2_LUMP_EDGES, bsp->numedges);
+            PrintLumpSize(lumpspec, Q2_LUMP_SURFEDGES, bsp->numsurfedges);
+            PrintLumpSize(lumpspec, Q2_LUMP_BRUSHES, bsp->numbrushes);
+            PrintLumpSize(lumpspec, Q2_LUMP_BRUSHSIDES, bsp->numbrushsides);
+            PrintLumpSize(lumpspec, Q2_LUMP_AREAS, bsp->numareas);
+            PrintLumpSize(lumpspec, Q2_LUMP_AREAPORTALS, bsp->numareaportals);
+        
+            logprint("%7s %-12s %10i\n", "", "lightdata", bsp->lightdatasize);
+            logprint("%7s %-12s %10i\n", "", "visdata", bsp->visdatasize);
+            logprint("%7s %-12s %10i\n", "", "entdata", bsp->entdatasize);
+        } else {
+            logprint("No idea what Q2BSP this is\n");
+        }
     }
     
     if (bspdata->version == BSPVERSION || bspdata->version == BSPHLVERSION) {

--- a/common/bspfile.cc
+++ b/common/bspfile.cc
@@ -568,12 +568,12 @@ void Q2_SwapBSPFile (q2bsp_t *bsp, qboolean todisk)
 
 /*
 =============
-Q2_QBSP_SwapBSPFile
+Q2_Qbism_SwapBSPFile
 
 Byte swaps all data in a bsp file.
 =============
 */
-void Q2_QBSP_SwapBSPFile (q2bsp_qbsp_t *bsp, qboolean todisk)
+void Q2_Qbism_SwapBSPFile (q2bsp_qbism_t *bsp, qboolean todisk)
 {
     int                i, j;
     q2_dmodel_t        *d;
@@ -775,8 +775,8 @@ SwapBSPFile(bspdata_t *bspdata, swaptype_t swap)
             q2bsp_t *bsp = &bspdata->data.q2bsp;
             Q2_SwapBSPFile(bsp, swap == TO_DISK);
         } else if (bspdata->ident == Q2_QBSPIDENT) {
-            q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
-            Q2_QBSP_SwapBSPFile(bsp, swap == TO_DISK);
+            q2bsp_qbism_t *bsp = &bspdata->data.q2bsp_qbism;
+            Q2_Qbism_SwapBSPFile(bsp, swap == TO_DISK);
         }
         
         return;
@@ -1013,8 +1013,8 @@ Q2BSPtoM_Leafs(const q2_dleaf_t *dleafsq2, int numleafs) {
 }
 
 static mleaf_t *
-Q2BSP_QBSPtoM_Leafs(const q2_dleaf_qbsp_t *dleafsq2, int numleafs) {
-    const q2_dleaf_qbsp_t *dleafq2 = dleafsq2;
+Q2BSP_QBSPtoM_Leafs(const q2_dleaf_qbism_t *dleafsq2, int numleafs) {
+    const q2_dleaf_qbism_t *dleafq2 = dleafsq2;
     mleaf_t *newdata, *mleaf;
     int i, j;
     
@@ -1066,13 +1066,13 @@ MBSPtoQ2_Leafs(const mleaf_t *mleafs, int numleafs) {
     return newdata;
 }
 
-static q2_dleaf_qbsp_t *
-MBSPtoQ2_QBSP_Leafs(const mleaf_t *mleafs, int numleafs) {
+static q2_dleaf_qbism_t *
+MBSPtoQ2_Qbism_Leafs(const mleaf_t *mleafs, int numleafs) {
     const mleaf_t *mleaf = mleafs;
-    q2_dleaf_qbsp_t *newdata, *dleafq2;
+    q2_dleaf_qbism_t *newdata, *dleafq2;
     int i, j;
     
-    newdata = dleafq2 = (q2_dleaf_qbsp_t *)calloc(numleafs, sizeof(*dleafq2));
+    newdata = dleafq2 = (q2_dleaf_qbism_t *)calloc(numleafs, sizeof(*dleafq2));
     
     for (i = 0; i < numleafs; i++, mleaf++, dleafq2++) {
         dleafq2->contents = mleaf->contents;
@@ -1162,8 +1162,8 @@ Q2BSPto2_Faces(const q2_dface_t *dfacesq2, int numfaces) {
 }
 
 static bsp2_dface_t *
-Q2BSP_QBSPto2_Faces(const q2_dface_qbsp_t *dfacesq2, int numfaces) {
-    const q2_dface_qbsp_t *dfaceq2 = dfacesq2;
+Q2BSP_QBSPto2_Faces(const q2_dface_qbism_t *dfacesq2, int numfaces) {
+    const q2_dface_qbism_t *dfaceq2 = dfacesq2;
     bsp2_dface_t *newdata, *dface2;
     int i, j;
     
@@ -1205,13 +1205,13 @@ BSP2toQ2_Faces(const bsp2_dface_t *dfaces2, int numfaces) {
     return newdata;
 }
 
-static q2_dface_qbsp_t *
-BSP2toQ2_QBSP_Faces(const bsp2_dface_t *dfaces2, int numfaces) {
+static q2_dface_qbism_t *
+BSP2toQ2_Qbism_Faces(const bsp2_dface_t *dfaces2, int numfaces) {
     const bsp2_dface_t *dface2 = dfaces2;
-    q2_dface_qbsp_t *newdata, *dfaceq2;
+    q2_dface_qbism_t *newdata, *dfaceq2;
     int i, j;
     
-    newdata = dfaceq2 = static_cast<q2_dface_qbsp_t *>(malloc(numfaces * sizeof(*dfaceq2)));
+    newdata = dfaceq2 = static_cast<q2_dface_qbism_t *>(malloc(numfaces * sizeof(*dfaceq2)));
     
     for (i = 0; i < numfaces; i++, dface2++, dfaceq2++) {
         dfaceq2->planenum = dface2->planenum;
@@ -1740,7 +1740,7 @@ static uint16_t *MBSPtoQ2_CopyLeafBrushes(const uint32_t *leafbrushes, int count
     return newdata;
 }
 
-static uint32_t *Q2BSP_QBSP_CopyLeafBrushes(const uint32_t *leafbrushes, int count)
+static uint32_t *Q2BSP_Qbism_CopyLeafBrushes(const uint32_t *leafbrushes, int count)
 {
     return (uint32_t *)CopyArray(leafbrushes, count, sizeof(*leafbrushes));
 }
@@ -1760,13 +1760,13 @@ static dbrush_t *Q2BSP_CopyBrushes(const dbrush_t *brushes, int count)
     return (dbrush_t *)CopyArray(brushes, count, sizeof(*brushes));
 }
 
-static q2_dbrushside_qbsp_t *Q2BSPtoM_CopyBrushSides(const dbrushside_t *dbrushsides, int count)
+static q2_dbrushside_qbism_t *Q2BSPtoM_CopyBrushSides(const dbrushside_t *dbrushsides, int count)
 {
     const dbrushside_t *brushside = dbrushsides;
-    q2_dbrushside_qbsp_t *newdata, *brushsides2;
+    q2_dbrushside_qbism_t *newdata, *brushsides2;
     int i;
 
-    newdata = brushsides2 = static_cast<q2_dbrushside_qbsp_t *>(malloc(count * sizeof(*brushsides2)));
+    newdata = brushsides2 = static_cast<q2_dbrushside_qbism_t *>(malloc(count * sizeof(*brushsides2)));
 
     for (i = 0; i < count; i++, brushside++, brushsides2++) {
         brushsides2->planenum = brushside->planenum;
@@ -1776,14 +1776,14 @@ static q2_dbrushside_qbsp_t *Q2BSPtoM_CopyBrushSides(const dbrushside_t *dbrushs
     return newdata;
 }
 
-static q2_dbrushside_qbsp_t *Q2BSP_QBSP_CopyBrushSides(const q2_dbrushside_qbsp_t *brushsides, int count)
+static q2_dbrushside_qbism_t *Q2BSP_Qbism_CopyBrushSides(const q2_dbrushside_qbism_t *brushsides, int count)
 {
-    return (q2_dbrushside_qbsp_t *)CopyArray(brushsides, count, sizeof(*brushsides));
+    return (q2_dbrushside_qbism_t *)CopyArray(brushsides, count, sizeof(*brushsides));
 }
 
-static dbrushside_t *MBSPtoQ2_CopyBrushSides(const q2_dbrushside_qbsp_t *dbrushsides, int count)
+static dbrushside_t *MBSPtoQ2_CopyBrushSides(const q2_dbrushside_qbism_t *dbrushsides, int count)
 {
-    const q2_dbrushside_qbsp_t *brushside = dbrushsides;
+    const q2_dbrushside_qbism_t *brushside = dbrushsides;
     dbrushside_t *newdata, *brushsides2;
     int i;
 
@@ -1887,7 +1887,7 @@ static void FreeQ2BSP(q2bsp_t *bsp)
     memset(bsp, 0, sizeof(*bsp));
 }
 
-static void FreeQ2BSP_QBSP(q2bsp_qbsp_t *bsp)
+static void FreeQ2BSP_QBSP(q2bsp_qbism_t *bsp)
 {
     free(bsp->dmodels);
     free(bsp->dvis);
@@ -2064,7 +2064,7 @@ ConvertBSPFormat(int32_t version, int32_t ident, bspdata_t *bspdata)
             /* Conversion complete! */
             ConvertBSPToMFormatComplete(&mbsp->loadversion, &mbsp->loadident, version, ident, bspdata);
         } else if (bspdata->ident == Q2_QBSPIDENT) {
-            const q2bsp_qbsp_t *q2bsp = &bspdata->data.q2bsp_qbsp;
+            const q2bsp_qbism_t *q2bsp = &bspdata->data.q2bsp_qbism;
             mbsp_t *mbsp = &bspdata->data.mbsp;
         
             memset(mbsp, 0, sizeof(*mbsp));
@@ -2102,17 +2102,17 @@ ConvertBSPFormat(int32_t version, int32_t ident, bspdata_t *bspdata)
             mbsp->dfaces = Q2BSP_QBSPto2_Faces(q2bsp->dfaces, q2bsp->numfaces);
             mbsp->dedges = BSP2_CopyEdges(q2bsp->dedges, q2bsp->numedges);
             mbsp->dleaffaces = BSP2_CopyMarksurfaces(q2bsp->dleaffaces, q2bsp->numleaffaces);
-            mbsp->dleafbrushes = Q2BSP_QBSP_CopyLeafBrushes(q2bsp->dleafbrushes, q2bsp->numleafbrushes);
+            mbsp->dleafbrushes = Q2BSP_Qbism_CopyLeafBrushes(q2bsp->dleafbrushes, q2bsp->numleafbrushes);
             mbsp->dsurfedges = BSP29_CopySurfedges(q2bsp->dsurfedges, q2bsp->numsurfedges);
         
             mbsp->dareas = Q2BSP_CopyAreas(q2bsp->dareas, q2bsp->numareas);
             mbsp->dareaportals = Q2BSP_CopyAreaPortals(q2bsp->dareaportals, q2bsp->numareaportals);
         
             mbsp->dbrushes = Q2BSP_CopyBrushes(q2bsp->dbrushes, q2bsp->numbrushes);
-            mbsp->dbrushsides = Q2BSP_QBSP_CopyBrushSides(q2bsp->dbrushsides, q2bsp->numbrushsides);
+            mbsp->dbrushsides = Q2BSP_Qbism_CopyBrushSides(q2bsp->dbrushsides, q2bsp->numbrushsides);
         
             /* Free old data */
-            FreeQ2BSP_QBSP((q2bsp_qbsp_t *)q2bsp);
+            FreeQ2BSP_QBSP((q2bsp_qbism_t *)q2bsp);
         
             /* Conversion complete! */
             ConvertBSPToMFormatComplete(&mbsp->loadversion, &mbsp->loadident, version, ident, bspdata);
@@ -2328,7 +2328,7 @@ ConvertBSPFormat(int32_t version, int32_t ident, bspdata_t *bspdata)
             bspdata->ident = ident;
         } else if (ident == Q2_QBSPIDENT) {
             const mbsp_t *mbsp = &bspdata->data.mbsp;
-            q2bsp_qbsp_t *q2bsp = &bspdata->data.q2bsp_qbsp;
+            q2bsp_qbism_t *q2bsp = &bspdata->data.q2bsp_qbism;
         
             memset(q2bsp, 0, sizeof(*q2bsp));
         
@@ -2357,22 +2357,22 @@ ConvertBSPFormat(int32_t version, int32_t ident, bspdata_t *bspdata)
             q2bsp->dvis = (dvis_t *)CopyArray(mbsp->dvisdata, mbsp->visdatasize, 1);
             q2bsp->dlightdata = BSP29_CopyLightData(mbsp->dlightdata, mbsp->lightdatasize);
             q2bsp->dentdata = BSP29_CopyEntData(mbsp->dentdata, mbsp->entdatasize);
-            q2bsp->dleafs = MBSPtoQ2_QBSP_Leafs(mbsp->dleafs, mbsp->numleafs);
+            q2bsp->dleafs = MBSPtoQ2_Qbism_Leafs(mbsp->dleafs, mbsp->numleafs);
             q2bsp->dplanes = BSP29_CopyPlanes(mbsp->dplanes, mbsp->numplanes);
             q2bsp->dvertexes = BSP29_CopyVertexes(mbsp->dvertexes, mbsp->numvertexes);
             q2bsp->dnodes = BSP2_CopyNodes(mbsp->dnodes, mbsp->numnodes);
             q2bsp->texinfo = MBSPtoQ2_Texinfo(mbsp->texinfo, mbsp->numtexinfo);
-            q2bsp->dfaces = BSP2toQ2_QBSP_Faces(mbsp->dfaces, mbsp->numfaces);
+            q2bsp->dfaces = BSP2toQ2_Qbism_Faces(mbsp->dfaces, mbsp->numfaces);
             q2bsp->dedges = BSP2_CopyEdges(mbsp->dedges, mbsp->numedges);
             q2bsp->dleaffaces = BSP2_CopyMarksurfaces(mbsp->dleaffaces, mbsp->numleaffaces);
-            q2bsp->dleafbrushes = Q2BSP_QBSP_CopyLeafBrushes(mbsp->dleafbrushes, mbsp->numleafbrushes);
+            q2bsp->dleafbrushes = Q2BSP_Qbism_CopyLeafBrushes(mbsp->dleafbrushes, mbsp->numleafbrushes);
             q2bsp->dsurfedges = BSP29_CopySurfedges(mbsp->dsurfedges, mbsp->numsurfedges);
         
             q2bsp->dareas = Q2BSP_CopyAreas(mbsp->dareas, mbsp->numareas);
             q2bsp->dareaportals = Q2BSP_CopyAreaPortals(mbsp->dareaportals, mbsp->numareaportals);
         
             q2bsp->dbrushes = Q2BSP_CopyBrushes(mbsp->dbrushes, mbsp->numbrushes);
-            q2bsp->dbrushsides = Q2BSP_QBSP_CopyBrushSides(mbsp->dbrushsides, mbsp->numbrushsides);
+            q2bsp->dbrushsides = Q2BSP_Qbism_CopyBrushSides(mbsp->dbrushsides, mbsp->numbrushsides);
         
             /* Free old data */
             FreeMBSP((mbsp_t *)mbsp);
@@ -2587,18 +2587,18 @@ const lumpspec_t lumpspec_q2bsp_qbsp[] = {
     { "planes",       sizeof(dplane_t)          },
     { "vertexes",     sizeof(dvertex_t)         },
     { "visibility",   sizeof(uint8_t)              },
-    { "nodes",        sizeof(q2_dnode_qbsp_t)        },
+    { "nodes",        sizeof(q2_dnode_qbism_t)        },
     { "texinfos",     sizeof(q2_texinfo_t)      },
-    { "faces",        sizeof(q2_dface_qbsp_t)        },
+    { "faces",        sizeof(q2_dface_qbism_t)        },
     { "lighting",     sizeof(uint8_t)              },
-    { "leafs",        sizeof(q2_dleaf_qbsp_t)        },
+    { "leafs",        sizeof(q2_dleaf_qbism_t)        },
     { "leaffaces",    sizeof(uint32_t)          },
     { "leafbrushes",  sizeof(uint32_t)          },
-    { "edges",        sizeof(q2_dedge_qbsp_t)     },
+    { "edges",        sizeof(q2_dedge_qbism_t)     },
     { "surfedges",    sizeof(int32_t)           },
     { "models",       sizeof(q2_dmodel_t)       },
     { "brushes",      sizeof(dbrush_t)          },
-    { "brushsides",   sizeof(q2_dbrushside_qbsp_t)      },
+    { "brushsides",   sizeof(q2_dbrushside_qbism_t)      },
     { "pop",          sizeof(uint8_t)              },
     { "areas",        sizeof(darea_t)           },
     { "areaportals",  sizeof(dareaportal_t)     },
@@ -2887,7 +2887,7 @@ LoadBSPFile(char *filename, bspdata_t *bspdata)
         
           Q2_CopyLump (header, Q2_LUMP_POP, &bsp->dpop);
         } else {
-            q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
+            q2bsp_qbism_t *bsp = &bspdata->data.q2bsp_qbism;
 
             memset(bsp, 0, sizeof(*bsp));
 
@@ -3244,7 +3244,7 @@ WriteBSPFile(const char *filename, bspdata_t *bspdata)
             AddLump(&bspfile, Q2_LUMP_ENTITIES, bsp->dentdata, bsp->entdatasize);
             AddLump(&bspfile, Q2_LUMP_POP, bsp->dpop, sizeof(bsp->dpop));
         } else if (bspdata->ident == Q2_QBSPIDENT) {
-            q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
+            q2bsp_qbism_t *bsp = &bspdata->data.q2bsp_qbism;
 
             AddLump(&bspfile, Q2_LUMP_MODELS, bsp->dmodels, bsp->nummodels);
             AddLump(&bspfile, Q2_LUMP_VERTEXES, bsp->dvertexes, bsp->numvertexes);
@@ -3369,7 +3369,7 @@ PrintBSPFileSizes(const bspdata_t *bspdata)
             logprint("%7s %-12s %10i\n", "", "visdata", bsp->visdatasize);
             logprint("%7s %-12s %10i\n", "", "entdata", bsp->entdatasize);
         } else if (bspdata->ident == Q2_QBSPIDENT) {
-            const q2bsp_qbsp_t *bsp = &bspdata->data.q2bsp_qbsp;
+            const q2bsp_qbism_t *bsp = &bspdata->data.q2bsp_qbism;
             const lumpspec_t *lumpspec = lumpspec_q2bsp_qbsp;
         
             logprint("%7i %-12s\n", bsp->nummodels, "models");

--- a/common/bsputils.cc
+++ b/common/bsputils.cc
@@ -185,7 +185,7 @@ bool Face_IsLightmapped(const mbsp_t *bsp, const bsp2_dface_t *face)
     if (texinfo == nullptr)
         return false;
     
-    if (bsp->loadversion == Q2_BSPVERSION) {
+    if (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism) {
         if (texinfo->flags & (Q2_SURF_WARP|Q2_SURF_SKY|Q2_SURF_NODRAW)) { //mxd. +Q2_SURF_NODRAW
             return false;
         }
@@ -220,7 +220,7 @@ TextureName_Contents(const char *texname)
 bool //mxd
 Contents_IsTranslucent(const mbsp_t *bsp, const int contents)
 {
-    if (bsp->loadversion == Q2_BSPVERSION)
+    if (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism)
         return (contents & Q2_SURF_TRANSLUCENT) && ((contents & Q2_SURF_TRANSLUCENT) != Q2_SURF_TRANSLUCENT); // Don't count KMQ2 fence flags combo as translucent
     else
         return contents == CONTENTS_WATER || contents == CONTENTS_LAVA || contents == CONTENTS_SLIME;
@@ -235,7 +235,7 @@ Face_IsTranslucent(const mbsp_t *bsp, const bsp2_dface_t *face)
 int //mxd. Returns CONTENTS_ value for Q1, Q2_SURF_ bitflags for Q2...
 Face_Contents(const mbsp_t *bsp, const bsp2_dface_t *face)
 {
-    if (bsp->loadversion == Q2_BSPVERSION) {
+    if (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism) {
         const gtexinfo_t *info = Face_Texinfo(bsp, face);
         return info->flags;
     } else {
@@ -274,8 +274,13 @@ static bool Light_PointInSolid_r(const mbsp_t *bsp, const int nodenum, const vec
 {
     if (nodenum < 0) {
         const mleaf_t *leaf = BSP_GetLeafFromNodeNum(bsp, nodenum);
+
+        //mxd
+        if (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism) {
+            return leaf->contents & Q2_CONTENTS_SOLID;
+        }
         
-        return (bsp->loadversion == Q2_BSPVERSION ? leaf->contents & Q2_CONTENTS_SOLID : (leaf->contents == CONTENTS_SOLID || leaf->contents == CONTENTS_SKY)); //mxd
+        return (leaf->contents == CONTENTS_SOLID || leaf->contents == CONTENTS_SKY);
     }
     
     const bsp2_dnode_t *node = &bsp->dnodes[nodenum];

--- a/include/common/bspfile.hh
+++ b/include/common/bspfile.hh
@@ -58,6 +58,7 @@
 #define BSPHLVERSION   30 //24bit lighting, and private palettes in the textures lump.
 #define Q2_BSPIDENT    (('P'<<24)+('S'<<16)+('B'<<8)+'I')
 #define Q2_BSPVERSION  38
+#define Q2_QBSPIDENT   (('P'<<24)+('S'<<16)+('B'<<8)+'Q')
 
 /* Not an actual file format, but the mbsp_t struct */
 /* TODO: Should probably separate the type tag for bspdata_t from the file
@@ -290,6 +291,8 @@ struct q2_dnode_t {
     uint16_t numfaces;    // counting both sides
 };
 
+using q2_dnode_qbsp_t = bsp2_dnode_t;
+
 /*
  * Note that children are interpreted as unsigned values now, so that we can
  * handle > 32k clipnodes. Values > 0xFFF0 can be assumed to be CONTENTS
@@ -387,6 +390,8 @@ typedef struct {
     uint32_t v[2];              /* vertex numbers */
 } bsp2_dedge_t;
 
+using q2_dedge_qbsp_t = bsp2_dedge_t;
+
 #define MAXLIGHTMAPS 4
 typedef struct {
     int16_t planenum;
@@ -423,6 +428,18 @@ typedef struct {
     uint8_t styles[MAXLIGHTMAPS];
     int32_t lightofs;        // start of [numstyles*surfsize] samples
 } q2_dface_t;
+
+typedef struct {
+    uint32_t planenum;		  // NOTE: only difference from bsp2_dface_t
+    int32_t side;
+    int32_t firstedge;        // we must support > 64k edges
+    int32_t numedges;
+    int32_t texinfo;
+    
+    // lighting info
+    uint8_t styles[MAXLIGHTMAPS];
+    int32_t lightofs;        // start of [numstyles*surfsize] samples
+} q2_dface_qbsp_t;
 
 /* Ambient Sounds */
 #define AMBIENT_WATER   0
@@ -482,6 +499,22 @@ typedef struct {
 } q2_dleaf_t;
 
 typedef struct {
+    int32_t contents;            // OR of all brushes (not needed?)
+    
+    int32_t cluster;
+    int32_t area;
+    
+    float mins[3];            // for frustum culling
+    float maxs[3];
+    
+    uint32_t firstleafface;
+    uint32_t numleaffaces;
+    
+    uint32_t firstleafbrush;
+    uint32_t numleafbrushes;
+} q2_dleaf_qbsp_t;
+
+typedef struct {
     // bsp2_dleaf_t
     int32_t contents;
     int32_t visofs;             /* -1 = no visibility info */
@@ -492,16 +525,21 @@ typedef struct {
     uint8_t ambient_level[NUM_AMBIENTS];
     
     // q2 extras
-        int16_t cluster;
-        int16_t area;
-        uint16_t firstleafbrush;
-        uint16_t numleafbrushes;
+    int32_t cluster;
+    int32_t area;
+    uint32_t firstleafbrush;
+    uint32_t numleafbrushes;
 } mleaf_t;
 
 typedef struct {
     uint16_t planenum;        // facing out of the leaf
     int16_t texinfo;
 } dbrushside_t;
+
+typedef struct {
+    uint32_t planenum;        // facing out of the leaf
+    int32_t texinfo;
+} q2_dbrushside_qbsp_t;
 
 typedef struct {
     int32_t firstside;
@@ -742,6 +780,64 @@ typedef struct {
     uint8_t dpop[256];
 } q2bsp_t;
 
+typedef struct {
+    int nummodels;
+    q2_dmodel_t *dmodels;
+    
+    int visdatasize;
+    dvis_t *dvis;
+    
+    int lightdatasize;
+    uint8_t *dlightdata;
+    
+    int entdatasize;
+    char *dentdata;
+    
+    int numleafs;
+    q2_dleaf_qbsp_t *dleafs;
+    
+    int numplanes;
+    dplane_t *dplanes;
+    
+    int numvertexes;
+    dvertex_t *dvertexes;
+    
+    int numnodes;
+    q2_dnode_qbsp_t *dnodes;
+    
+    int numtexinfo;
+    q2_texinfo_t *texinfo;
+    
+    int numfaces;
+    q2_dface_qbsp_t *dfaces;
+    
+    int numedges;
+    q2_dedge_qbsp_t *dedges;
+    
+    int numleaffaces;
+    uint32_t *dleaffaces;
+    
+    int numleafbrushes;
+    uint32_t *dleafbrushes;
+    
+    int numsurfedges;
+    int32_t *dsurfedges;
+    
+    int numareas;
+    darea_t *dareas;
+    
+    int numareaportals;
+    dareaportal_t *dareaportals;
+    
+    int numbrushes;
+    dbrush_t *dbrushes;
+    
+    int numbrushsides;
+    q2_dbrushside_qbsp_t *dbrushsides;
+    
+    uint8_t dpop[256];
+} q2bsp_qbsp_t;
+
 struct mbsp_t {
     int32_t loadversion;
     
@@ -792,7 +888,7 @@ struct mbsp_t {
     uint32_t *dleaffaces;
     
     int numleafbrushes;
-    uint16_t *dleafbrushes;
+    uint32_t *dleafbrushes;
     
     int numsurfedges;
     int32_t *dsurfedges;
@@ -807,7 +903,7 @@ struct mbsp_t {
     dbrush_t *dbrushes;
     
     int numbrushsides;
-    dbrushside_t *dbrushsides;
+    q2_dbrushside_qbsp_t *dbrushsides;
     
     uint8_t dpop[256];
 }; // "generic" bsp - superset of all other supported types
@@ -824,6 +920,7 @@ typedef struct {
 } q2_dheader_t;
 
 typedef struct {
+    int32_t ident;
     int32_t loadversion;
     int32_t version;
     int hullcount;
@@ -834,6 +931,7 @@ typedef struct {
         bsp2_t bsp2;
         q2bsp_t q2bsp;
         mbsp_t mbsp;
+        q2bsp_qbsp_t q2bsp_qbsp;
     } data;
 
     bspxentry_t *bspxentries;

--- a/include/common/bspfile.hh
+++ b/include/common/bspfile.hh
@@ -52,18 +52,41 @@
 #define MAX_ENT_KEY   32
 #define MAX_ENT_VALUE 1024
 
+struct bspversion_t
+{
+    /* identifier value, the first int32_t in the header */
+    int32_t ident;
+    /* version value, if supported; use NO_VERSION if a version is not required */
+    int32_t version;
+    /* short name used for command line args, etc */
+    const char *short_name;
+    /* full display name for printing */
+    const char *name;
+};
+
+#define NO_VERSION      -1
+
 #define BSPVERSION     29
 #define BSP2RMQVERSION (('B' << 24) | ('S' << 16) | ('P' << 8) | '2')
 #define BSP2VERSION    ('B' | ('S' << 8) | ('P' << 16) | ('2' << 24))
 #define BSPHLVERSION   30 //24bit lighting, and private palettes in the textures lump.
 #define Q2_BSPIDENT    (('P'<<24)+('S'<<16)+('B'<<8)+'I')
 #define Q2_BSPVERSION  38
-#define Q2_QBSPIDENT   (('P'<<24)+('S'<<16)+('B'<<8)+'Q')
+#define Q2_QBISMIDENT  (('P'<<24)+('S'<<16)+('B'<<8)+'Q')
 
-/* Not an actual file format, but the mbsp_t struct */
-/* TODO: Should probably separate the type tag for bspdata_t from the file
-   version numbers */
-#define GENERIC_BSP	   99
+extern const bspversion_t bspver_generic, bspver_q1, bspver_h2, bspver_bsp2, bspver_bsp2rmq, bspver_hl, bspver_q2, bspver_qbism;
+
+/* table of supported versions */
+constexpr const bspversion_t *const bspversions[] = {
+    &bspver_generic,
+    &bspver_q1,
+    &bspver_h2,
+    &bspver_bsp2,
+    &bspver_bsp2rmq,
+    &bspver_hl,
+    &bspver_q2,
+    &bspver_qbism
+};
 
 typedef struct {
     int32_t fileofs;
@@ -839,10 +862,7 @@ typedef struct {
 } q2bsp_qbism_t;
 
 struct mbsp_t {
-    // FIXME: rather than using version/ident, a unique identifier not connected
-    // to the original ident/versions should be used, so that versions with identical
-    // identifiers and/or versions can be matched accordingly.
-    int32_t loadversion, loadident;
+    const bspversion_t *loadversion;
     
     int nummodels;
     dmodelh2_t *dmodels;
@@ -923,13 +943,7 @@ typedef struct {
 } q2_dheader_t;
 
 typedef struct {
-    // FIXME: rather than using version/ident, a unique identifier not connected
-    // to the original ident/versions should be used, so that versions with identical
-    // identifiers and/or versions can be matched accordingly.
-    int32_t loadident;
-    int32_t ident;
-    int32_t loadversion;
-    int32_t version;
+    const bspversion_t *version, *loadversion;
     int hullcount;
     
     struct {
@@ -947,7 +961,7 @@ typedef struct {
 void LoadBSPFile(char *filename, bspdata_t *bspdata);       //returns the filename as contained inside a bsp
 void WriteBSPFile(const char *filename, bspdata_t *bspdata);
 void PrintBSPFileSizes(const bspdata_t *bspdata);
-void ConvertBSPFormat(int32_t version, int32_t ident, bspdata_t *bspdata);
+void ConvertBSPFormat(bspdata_t *bspdata, const bspversion_t *to_version);
 void BSPX_AddLump(bspdata_t *bspdata, const char *xname, const void *xdata, size_t xsize);
 const void *BSPX_GetLump(bspdata_t *bspdata, const char *xname, size_t *xsize);
 

--- a/include/common/bspfile.hh
+++ b/include/common/bspfile.hh
@@ -839,7 +839,10 @@ typedef struct {
 } q2bsp_qbsp_t;
 
 struct mbsp_t {
-    int32_t loadversion;
+    // FIXME: rather than using version/ident, a unique identifier not connected
+    // to the original ident/versions should be used, so that versions with identical
+    // identifiers and/or versions can be matched accordingly.
+    int32_t loadversion, loadident;
     
     int nummodels;
     dmodelh2_t *dmodels;
@@ -920,6 +923,10 @@ typedef struct {
 } q2_dheader_t;
 
 typedef struct {
+    // FIXME: rather than using version/ident, a unique identifier not connected
+    // to the original ident/versions should be used, so that versions with identical
+    // identifiers and/or versions can be matched accordingly.
+    int32_t loadident;
     int32_t ident;
     int32_t loadversion;
     int32_t version;
@@ -940,7 +947,7 @@ typedef struct {
 void LoadBSPFile(char *filename, bspdata_t *bspdata);       //returns the filename as contained inside a bsp
 void WriteBSPFile(const char *filename, bspdata_t *bspdata);
 void PrintBSPFileSizes(const bspdata_t *bspdata);
-void ConvertBSPFormat(int32_t version, bspdata_t *bspdata);
+void ConvertBSPFormat(int32_t version, int32_t ident, bspdata_t *bspdata);
 void BSPX_AddLump(bspdata_t *bspdata, const char *xname, const void *xdata, size_t xsize);
 const void *BSPX_GetLump(bspdata_t *bspdata, const char *xname, size_t *xsize);
 

--- a/include/common/bspfile.hh
+++ b/include/common/bspfile.hh
@@ -291,7 +291,7 @@ struct q2_dnode_t {
     uint16_t numfaces;    // counting both sides
 };
 
-using q2_dnode_qbsp_t = bsp2_dnode_t;
+using q2_dnode_qbism_t = bsp2_dnode_t;
 
 /*
  * Note that children are interpreted as unsigned values now, so that we can
@@ -390,7 +390,7 @@ typedef struct {
     uint32_t v[2];              /* vertex numbers */
 } bsp2_dedge_t;
 
-using q2_dedge_qbsp_t = bsp2_dedge_t;
+using q2_dedge_qbism_t = bsp2_dedge_t;
 
 #define MAXLIGHTMAPS 4
 typedef struct {
@@ -439,7 +439,7 @@ typedef struct {
     // lighting info
     uint8_t styles[MAXLIGHTMAPS];
     int32_t lightofs;        // start of [numstyles*surfsize] samples
-} q2_dface_qbsp_t;
+} q2_dface_qbism_t;
 
 /* Ambient Sounds */
 #define AMBIENT_WATER   0
@@ -512,7 +512,7 @@ typedef struct {
     
     uint32_t firstleafbrush;
     uint32_t numleafbrushes;
-} q2_dleaf_qbsp_t;
+} q2_dleaf_qbism_t;
 
 typedef struct {
     // bsp2_dleaf_t
@@ -539,7 +539,7 @@ typedef struct {
 typedef struct {
     uint32_t planenum;        // facing out of the leaf
     int32_t texinfo;
-} q2_dbrushside_qbsp_t;
+} q2_dbrushside_qbism_t;
 
 typedef struct {
     int32_t firstside;
@@ -794,7 +794,7 @@ typedef struct {
     char *dentdata;
     
     int numleafs;
-    q2_dleaf_qbsp_t *dleafs;
+    q2_dleaf_qbism_t *dleafs;
     
     int numplanes;
     dplane_t *dplanes;
@@ -803,16 +803,16 @@ typedef struct {
     dvertex_t *dvertexes;
     
     int numnodes;
-    q2_dnode_qbsp_t *dnodes;
+    q2_dnode_qbism_t *dnodes;
     
     int numtexinfo;
     q2_texinfo_t *texinfo;
     
     int numfaces;
-    q2_dface_qbsp_t *dfaces;
+    q2_dface_qbism_t *dfaces;
     
     int numedges;
-    q2_dedge_qbsp_t *dedges;
+    q2_dedge_qbism_t *dedges;
     
     int numleaffaces;
     uint32_t *dleaffaces;
@@ -833,10 +833,10 @@ typedef struct {
     dbrush_t *dbrushes;
     
     int numbrushsides;
-    q2_dbrushside_qbsp_t *dbrushsides;
+    q2_dbrushside_qbism_t *dbrushsides;
     
     uint8_t dpop[256];
-} q2bsp_qbsp_t;
+} q2bsp_qbism_t;
 
 struct mbsp_t {
     // FIXME: rather than using version/ident, a unique identifier not connected
@@ -906,7 +906,7 @@ struct mbsp_t {
     dbrush_t *dbrushes;
     
     int numbrushsides;
-    q2_dbrushside_qbsp_t *dbrushsides;
+    q2_dbrushside_qbism_t *dbrushsides;
     
     uint8_t dpop[256];
 }; // "generic" bsp - superset of all other supported types
@@ -938,7 +938,7 @@ typedef struct {
         bsp2_t bsp2;
         q2bsp_t q2bsp;
         mbsp_t mbsp;
-        q2bsp_qbsp_t q2bsp_qbsp;
+        q2bsp_qbism_t q2bsp_qbism;
     } data;
 
     bspxentry_t *bspxentries;

--- a/light/entities.cc
+++ b/light/entities.cc
@@ -1579,7 +1579,7 @@ static void MakeSurfaceLights(const mbsp_t *bsp)
     
     for (int i = 0; i < bsp->numleafs; i++) {
         const mleaf_t *leaf = bsp->dleafs + i;
-        const qboolean underwater = (bsp->loadversion == Q2_BSPVERSION ? leaf->contents & Q2_CONTENTS_LIQUID : leaf->contents != CONTENTS_EMPTY); //mxd
+        const qboolean underwater = ((bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism) ? leaf->contents & Q2_CONTENTS_LIQUID : leaf->contents != CONTENTS_EMPTY); //mxd
 
         for (int k = 0; k < leaf->nummarksurfaces; k++) {
             const int facenum = bsp->dleaffaces[leaf->firstmarksurface + k];

--- a/light/imglib.cc
+++ b/light/imglib.cc
@@ -44,7 +44,7 @@ void // WHO TOUCHED MY PALET?
 LoadPalette(bspdata_t *bspdata)
 {
     // Load Quake 2 palette
-    if (bspdata->loadversion == Q2_BSPVERSION) {
+    if (bspdata->loadversion == &bspver_q2 || bspdata->loadversion == &bspver_qbism) {
         uint8_t *palette;
         char path[1024];
         char colormap[] = "pics/colormap.pcx";
@@ -66,7 +66,7 @@ LoadPalette(bspdata_t *bspdata)
         for (int i = 0; i < 768; i++)
             thepalette[i] = palette[i];
 
-    } else if (bspdata->hullcount == MAX_MAP_HULLS_H2) { // Gross hacks
+    } else if (bspdata->loadversion == &bspver_h2) {
         // Copy Hexen 2 palette
         for (int i = 0; i < 768; i++)
             thepalette[i] = hexen2palette[i];
@@ -721,7 +721,7 @@ void // Expects correct palette and game/mod paths to be set
 LoadOrConvertTextures(mbsp_t *bsp)
 {
     // Load or convert textures...
-    if (bsp->loadversion == Q2_BSPVERSION)
+    if (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism)
         LoadTextures(bsp);
     else if (bsp->texdatasize > 0)
         ConvertTextures(bsp);

--- a/light/light.cc
+++ b/light/light.cc
@@ -951,7 +951,7 @@ light_main(int argc, const char **argv)
 {
     bspdata_t bspdata;
     mbsp_t *const bsp = &bspdata.data.mbsp;
-    int32_t loadversion;
+    int32_t loadversion, loadident;
     int i;
     double start;
     double end;
@@ -1199,7 +1199,8 @@ light_main(int argc, const char **argv)
     LoadBSPFile(source, &bspdata);
 
     loadversion = bspdata.version;
-    ConvertBSPFormat(GENERIC_BSP, &bspdata);
+    loadident = bspdata.ident;
+    ConvertBSPFormat(GENERIC_BSP, -1, &bspdata);
 
     //mxd. Use 1.0 rangescale as a default to better match with qrad3/arghrad
     if (loadversion == Q2_BSPVERSION && !cfg.rangescale.isChanged())
@@ -1281,7 +1282,7 @@ light_main(int argc, const char **argv)
     
     WriteEntitiesToString(cfg, bsp);
     /* Convert data format back if necessary */
-    ConvertBSPFormat(loadversion, &bspdata);
+    ConvertBSPFormat(loadversion, loadident, &bspdata);
 
     if (!litonly) {
         WriteBSPFile(source, &bspdata);

--- a/light/light.cc
+++ b/light/light.cc
@@ -439,7 +439,7 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     CalcualateVertexNormals(bsp);
     
     const qboolean bouncerequired = cfg_static.bounce.boolValue() && (debugmode == debugmode_none || debugmode == debugmode_bounce || debugmode == debugmode_bouncelights); //mxd
-    const qboolean isQuake2map = (bsp->loadversion == Q2_BSPVERSION); //mxd
+    const qboolean isQuake2map = (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism); //mxd
 
     if (bouncerequired || isQuake2map) {
         MakeTextureColors(bsp);
@@ -470,7 +470,7 @@ LightWorld(bspdata_t *bspdata, qboolean forcedscale)
     // Transfer greyscale lightmap (or color lightmap for Q2/HL) to the bsp and update lightdatasize
     if (!litonly) {
         free(bsp->dlightdata);
-        if (bsp->loadversion == Q2_BSPVERSION || bsp->loadversion == BSPHLVERSION) {
+        if (isQuake2map || bsp->loadversion == &bspver_hl) {
             bsp->lightdatasize = lit_file_p;
             bsp->dlightdata = (uint8_t *)malloc(bsp->lightdatasize);
             memcpy(bsp->dlightdata, lit_filebase, bsp->lightdatasize);
@@ -545,9 +545,9 @@ LoadExtendedTexinfoFlags(const char *sourcefilename, const mbsp_t *bsp)
 static const char* //mxd
 GetBaseDirName(bspdata_t *bspdata)
 {
-    if (bspdata->loadversion == Q2_BSPVERSION)
+    if (bspdata->loadversion == &bspver_q2 || bspdata->loadversion == &bspver_qbism)
         return "BASEQ2";
-    if (bspdata->hullcount == MAX_MAP_HULLS_H2)
+    if (bspdata->loadversion == &bspver_h2)
         return "DATA1";
     return "ID1";
 }
@@ -951,7 +951,7 @@ light_main(int argc, const char **argv)
 {
     bspdata_t bspdata;
     mbsp_t *const bsp = &bspdata.data.mbsp;
-    int32_t loadversion, loadident;
+    const bspversion_t *loadversion;
     int i;
     double start;
     double end;
@@ -1199,11 +1199,10 @@ light_main(int argc, const char **argv)
     LoadBSPFile(source, &bspdata);
 
     loadversion = bspdata.version;
-    loadident = bspdata.ident;
-    ConvertBSPFormat(GENERIC_BSP, -1, &bspdata);
+    ConvertBSPFormat(&bspdata, &bspver_generic);
 
     //mxd. Use 1.0 rangescale as a default to better match with qrad3/arghrad
-    if (loadversion == Q2_BSPVERSION && !cfg.rangescale.isChanged())
+    if ((loadversion == &bspver_q2 || loadversion == &bspver_qbism) && !cfg.rangescale.isChanged())
     {
         const auto rs = new lockable_vec_t(cfg.rangescale.primaryName(), 1.0f, 0.0f, 100.0f);
         cfg.rangescale = *rs; // Gross hacks to avoid displaying this in OptionsSummary...
@@ -1243,7 +1242,7 @@ light_main(int argc, const char **argv)
     
     if (!onlyents)
     {
-        if (loadversion != Q2_BSPVERSION && bsp->loadversion != BSPHLVERSION) //mxd. No lit for Quake 2
+        if (loadversion != &bspver_q2 && loadversion != &bspver_qbism && bsp->loadversion != &bspver_hl) //mxd. No lit for Quake 2
             CheckLitNeeded(cfg);
         SetupDirt(cfg);
         
@@ -1282,7 +1281,7 @@ light_main(int argc, const char **argv)
     
     WriteEntitiesToString(cfg, bsp);
     /* Convert data format back if necessary */
-    ConvertBSPFormat(loadversion, loadident, &bspdata);
+    ConvertBSPFormat(&bspdata, loadversion);
 
     if (!litonly) {
         WriteBSPFile(source, &bspdata);

--- a/light/ltface.cc
+++ b/light/ltface.cc
@@ -1034,7 +1034,7 @@ GetLightContrib(const globalconfig_t &cfg, const light_t *entity, const vec3_t s
     if (dist < 0.1) {
         // Catch 0 distance between sample point and light (produces infinite brightness / nan's) and causes
         // problems later
-        dist = 0.1;
+        dist = 0.1f;
         VectorSet(surfpointToLightDir_out, 0, 0, 1);
     }
     const float add = GetLightValueWithAngle(cfg, entity, surfnorm, surfpointToLightDir_out, dist, twosided);
@@ -3081,7 +3081,7 @@ WriteLightmaps(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const 
             continue;
         
         // skip lightmaps where all samples have brightness below 1
-        if (bsp->loadversion != Q2_BSPVERSION) { // HACK: don't do this on Q2. seems if all styles are 0xff, the face is drawn fullbright instead of black (Q1)
+        if (bsp->loadversion != &bspver_q2 && bsp->loadversion != &bspver_qbism) { // HACK: don't do this on Q2. seems if all styles are 0xff, the face is drawn fullbright instead of black (Q1)
             const float maxb = Lightmap_MaxBrightness(&lightmap, lightsurf);
             if (maxb < 1)
                 continue;
@@ -3146,7 +3146,7 @@ WriteLightmaps(const mbsp_t *bsp, bsp2_dface_t *face, facesup_t *facesup, const 
 
     // q2 support
     int lightofs;
-    if (bsp->loadversion == Q2_BSPVERSION || bsp->loadversion == BSPHLVERSION) {
+    if (bsp->loadversion == &bspver_q2 || bsp->loadversion == &bspver_qbism || bsp->loadversion == &bspver_hl) {
         lightofs = lit - lit_filebase;
     } else {
         lightofs = out - filebase;

--- a/light/trace.cc
+++ b/light/trace.cc
@@ -716,7 +716,7 @@ TraceFaces (traceinfo_t *ti, int node, const vec3_t start, const vec3_t end)
             
             // only solid and sky faces stop the trace.
             bool issolid, issky; //mxd
-            if(bsp_static->loadversion == Q2_BSPVERSION) {
+            if(bsp_static->loadversion == &bspver_q2 || bsp_static->loadversion == &bspver_qbism) {
                 issolid = !(fi->content & Q2_SURF_TRANSLUCENT);
                 issky = (fi->content & Q2_SURF_SKY);
             } else {

--- a/vis/vis.cc
+++ b/vis/vis.cc
@@ -1234,7 +1234,7 @@ main(int argc, char **argv)
 {
     bspdata_t bspdata;
     mbsp_t *const bsp = &bspdata.data.mbsp;
-    int32_t loadversion, loadident;
+    const bspversion_t *loadversion;
     int i;
 
     init_log("vis.log");
@@ -1309,8 +1309,7 @@ main(int argc, char **argv)
     LoadBSPFile(sourcefile, &bspdata);
 
     loadversion = bspdata.version;
-    loadident = bspdata.ident;
-    ConvertBSPFormat(GENERIC_BSP, -1, &bspdata);
+    ConvertBSPFormat(&bspdata, &bspver_generic);
 
     strcpy(portalfile, argv[i]);
     StripExtension(portalfile);
@@ -1342,7 +1341,7 @@ main(int argc, char **argv)
     CalcAmbientSounds(bsp);
 
     /* Convert data format back if necessary */
-    ConvertBSPFormat(loadversion, loadident, &bspdata);
+    ConvertBSPFormat(&bspdata, loadversion);
 
     WriteBSPFile(sourcefile, &bspdata);
 

--- a/vis/vis.cc
+++ b/vis/vis.cc
@@ -1233,7 +1233,7 @@ main(int argc, char **argv)
 {
     bspdata_t bspdata;
     mbsp_t *const bsp = &bspdata.data.mbsp;
-    int32_t loadversion;
+    int32_t loadversion, loadident;
     int i;
 
     init_log("vis.log");
@@ -1305,7 +1305,8 @@ main(int argc, char **argv)
     LoadBSPFile(sourcefile, &bspdata);
 
     loadversion = bspdata.version;
-    ConvertBSPFormat(GENERIC_BSP, &bspdata);
+    loadident = bspdata.ident;
+    ConvertBSPFormat(GENERIC_BSP, -1, &bspdata);
 
     strcpy(portalfile, argv[i]);
     StripExtension(portalfile);
@@ -1337,7 +1338,7 @@ main(int argc, char **argv)
     CalcAmbientSounds(bsp);
 
     /* Convert data format back if necessary */
-    ConvertBSPFormat(loadversion, &bspdata);
+    ConvertBSPFormat(loadversion, loadident, &bspdata);
 
     WriteBSPFile(sourcefile, &bspdata);
 


### PR DESCRIPTION
The framework for Q2BSP extended (QBSP) from Qbism's tools. Since it's basically a copy of BSP2, it uses a lot of the functions from there.

The hardest part was needing to pass ident around, because (like Q1BSP) the ident is what is changed here, not the version # which is still 38. 