### PR TITLE
bsputil: write ents in binary mode and print its crc in 4-digit hex

### DIFF
--- a/bsputil/bsputil.cc
+++ b/bsputil/bsputil.cc
@@ -593,11 +593,12 @@ main(int argc, char **argv)
             WriteBSPFile(source, &bspdata);
             
         } else if (!strcmp(argv[i], "--extract-entities")) {
+            unsigned int crc = CRC_Block((unsigned char *)bsp->dentdata, bsp->entdatasize - 1);
             StripExtension(source);
             DefaultExtension(source, ".ent");
-            printf("-> writing %s... ", source);
+            printf("-> writing %s [CRC: %04x]... ", source, crc);
 
-            f = fopen(source, "w");
+            f = fopen(source, "wb");
             if (!f)
                 Error("couldn't open %s for writing\n", source);
 

--- a/common/cmdlib.cc
+++ b/common/cmdlib.cc
@@ -1115,6 +1115,15 @@ CRC_Value(unsigned short crcvalue)
     return crcvalue ^ CRC_XOR_VALUE;
 }
 
+unsigned short CRC_Block (const unsigned char *start, int count)
+{
+    unsigned short crc;
+    CRC_Init (&crc);
+    while (count--)
+        crc = (crc << 8) ^ crctable[(crc >> 8) ^ *start++];
+    return crc;
+}
+
 /* ========================================================================= */
 
 /*

--- a/include/common/cmdlib.hh
+++ b/include/common/cmdlib.hh
@@ -125,6 +125,7 @@ char *copystring(const char *s);
 void CRC_Init(unsigned short *crcvalue);
 void CRC_ProcessByte(unsigned short *crcvalue, uint8_t data);
 unsigned short CRC_Value(unsigned short crcvalue);
+unsigned short CRC_Block (const unsigned char *start, int count);
 
 void CreatePath(char *path);
 void Q_CopyFile(const char *from, char *to);


### PR DESCRIPTION
This is in line with recent quakespasm/vkquake external ent file support
change so that the external ent file name is versioned using 4 digit crc
of the original map's ents. Without binary mode writing, the written ent
file will change its line endings under windows and the calculated crc16
from it will be wrong.
