### PR TITLE
Fix build on gcc 12.1

### DIFF
--- a/common/test.cc
+++ b/common/test.cc
@@ -371,10 +371,7 @@ TEST_CASE("resetContainer", "[settings]")
     CHECK("abc" == stringSetting1.value());
 }
 
-// this is insanely dumb, is there a better way of doing this?
-#define private public
 #include "common/polylib.hh"
-#undef private
 
 TEST_CASE("winding iterators", "[winding_base_t]")
 {

--- a/include/common/polylib.hh
+++ b/include/common/polylib.hh
@@ -44,11 +44,11 @@ private:
     using array_type = std::array<qvec3d, N>;
     using vector_type = std::vector<qvec3d>;
     using variant_type = std::variant<array_type, vector_type>;
+
+public:
     size_t count = 0;
     array_type array;
     vector_type vector;
-
-public:
     template<bool is_const>
     class iterator_base
     {


### PR DESCRIPTION
I get errors when try to build package I maintain on AUR:

```
In file included from /tmp/makepkg/ericw-tools-git/src/ericw-tools/include/common/bspfile.hh:28,
                 from /tmp/makepkg/ericw-tools-git/src/ericw-tools/include/common/polylib.hh:6,
                 from /tmp/makepkg/ericw-tools-git/src/ericw-tools/common/test.cc:376:
/usr/include/c++/12.1.0/any:370:7: error: ‘struct std::any::_Manager_internal<_Tp>’ redeclared with different access
  370 |       struct _Manager_internal
      |       ^~~~~~
/usr/include/c++/12.1.0/any:402:7: error: ‘struct std::any::_Manager_external<_Tp>’ redeclared with different access
  402 |       struct _Manager_external
      |       ^~~~~~
make[2]: *** [common/CMakeFiles/testcommon.dir/build.make:76: common/CMakeFiles/testcommon.dir/test.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:380: common/CMakeFiles/testcommon.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

With these changes it compiles now.