### PR TITLE
include cstdint in vec.hh to fix build

### DIFF
--- a/include/common/qvec.hh
+++ b/include/common/qvec.hh
@@ -22,6 +22,7 @@
 #include <initializer_list>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <string>
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
Build was failing for me on Linux because it lacked `cstdint` for `uint8_t` references in `vec.hh`.