### PR TITLE
vis algorithm improvement (2h42 -> 57m on ad_dm5)

### DIFF
--- a/include/vis/leafbits.hh
+++ b/include/vis/leafbits.hh
@@ -81,6 +81,7 @@ public:
     inline void resize(size_t new_size) { *this = leafbits_t(new_size); }
 
     inline void clear() { memset(bits.get(), 0, byte_size()); }
+    inline void setall() { memset(bits.get(), 0xff, byte_size()); }
 
     inline uint32_t *data() { return bits.get(); }
     inline const uint32_t *data() const { return bits.get(); }

--- a/include/vis/vis.hh
+++ b/include/vis/vis.hh
@@ -279,7 +279,7 @@ public:
         this, "phsonly", false, &vis_advanced_group, "re-calculate the PHS of a Quake II BSP without touching the PVS"};
     setting_invertible_bool autoclean{
         this, "autoclean", true, &vis_output_group, "remove any extra files on successful completion"};
-    setting_scalar targetratio{this, "targetchecks", 0.0, 0.0, 9999.0, &performance_group,
+    setting_scalar targetratio{this, "targetchecks", 0.5, 0.0, 9999.0, &performance_group,
         "target ratio of target checks to regular checks (0.0 = no target checks, 1.0 = equal amounts of regular and target checks)"};
 
     fs::path sourceMap;

--- a/include/vis/vis.hh
+++ b/include/vis/vis.hh
@@ -173,6 +173,8 @@ struct pstack_t
     leafbits_t *mightsee; // bit string
     qplane3d separators[2][MAX_SEPARATORS]; /* Separator cache */
     int numseparators[2];
+    char did_targetchecks;
+    unsigned num_expected_targetchecks;
 };
 
 // important for perf as a ton of these are stack allocated, needs to be be just a pointer bump
@@ -190,6 +192,7 @@ struct visstats_t
     int64_t c_chains = 0;
     int64_t c_leafskip = 0;
     int64_t c_portalskip = 0;
+    int64_t c_targetcheck = 0;
 
     visstats_t operator+(const visstats_t& other) const {
         visstats_t result;
@@ -203,6 +206,7 @@ struct visstats_t
         result.c_chains = this->c_chains + other.c_chains;
         result.c_leafskip = this->c_leafskip + other.c_leafskip;
         result.c_portalskip = this->c_portalskip + other.c_portalskip;
+        result.c_targetcheck = this->c_targetcheck + other.c_targetcheck;
         return result;
     }
 };
@@ -217,6 +221,8 @@ struct threaddata_t
     visportal_t *base;
     pstack_t pstack_head;
     visstats_t stats;
+    unsigned numsteps;
+    unsigned numtargetchecks;
 };
 
 extern int numportals;
@@ -273,6 +279,8 @@ public:
         this, "phsonly", false, &vis_advanced_group, "re-calculate the PHS of a Quake II BSP without touching the PVS"};
     setting_invertible_bool autoclean{
         this, "autoclean", true, &vis_output_group, "remove any extra files on successful completion"};
+    setting_scalar targetratio{this, "targetchecks", 0.0, 0.0, 9999.0, &performance_group,
+        "target ratio of target checks to regular checks (0.0 = no target checks, 1.0 = equal amounts of regular and target checks)"};
 
     fs::path sourceMap;
 

--- a/vis/vis.cc
+++ b/vis/vis.cc
@@ -524,6 +524,7 @@ visstats_t CalcPortalVis(const mbsp_t *bsp)
         stats.c_portaltest, stats.c_portalpass);
     logging::print(logging::flag::VERBOSE, "c_vistest: {}  c_mighttest: {}  c_mightseeupdate {}\n", stats.c_vistest,
         stats.c_mighttest, stats.c_mightseeupdate);
+    logging::print(logging::flag::VERBOSE, "c_targetcheck: {}\n", stats.c_targetcheck);
 
     return stats;
 }


### PR DESCRIPTION
I have developed a bounded-overhead method to further reduce work in the recursive vis process and ported it to ericw-vis. It has one tweakable which this patch exposes via command-line argument -targetchecks, where "-targetchecks 0" corresponds to the usual behavior, and "-targetchecks 1" will at most double vis time.

Different maps respond differently well:
- Very simple maps ones are slowed down: ad_e1m1 runtime increases by 23% (targetchecks=1, 43s -> 53s) though that's still less than the theoretical 100% increase.
- On a more complex map (E3M5-test) runtime decreases slightly by 10% (targetchecks=0.4, 58s -> 52s)
- On very complex maps (ad_dm5) runtime can decrease by 60% (targetchecks=0.45 2h42 -> 57m)

The X axis in this chart is the "-targetchecks" setting, Y axis is runtime:
![Screenshot_2023-06-18_22-28-38](https://github.com/ericwa/ericw-tools/assets/14948304/8dfa3eaf-6f87-4033-8043-37a9cbd2907a)

The idea is to check portal visibilities directly instead of brute-forcing every single path towards it. If a portal isn't even visible when ignoring the ones between the current source/pass and itself, then it certainly won't be with all the portals in-between. The number of targets (mightsee & ~vis) is in the hundreds though, while the number of portals leading out of a leaf is ~5. So target checks are not affordable at every single step.
This patch counts the number of adjacent portals processed and compares it to the number of targets. It can then occasionally trigger target checks while keeping a ratio of adjacent and target portal checks, thus bounding the overhead.

The code has been ported three times (my own vis → hlvis → ericw-vis(master) → ericw-vis(brushbsp)) so some bugs might've snuck in. In doubt, the code in TargetChecks should mirror the one in RecursiveLeafFlow.

One artifact of this is that the original version expected mighsee to be indexed by portal instead of leaf. Thus nummightsee was a number of portals and numExpectedTargetChecks as well. This number was then compared with numSteps (also a number of portals) and all was fine.
In this version, nummightsee is a count of leafs, so the condition to call IterativeTargetChecks is comparing different units. This is fine however since the counters are later updated with numActualTargetChecks which is in portals again.

I understand I sent this PR is out of the blue, so it you don't feel confident reviewing it or consider it out of scope for your project that's fine too. I'm happy to explain more or make adjustments.