### PR TITLE
-notex should now work

### DIFF
--- a/qbsp/qbsp.cc
+++ b/qbsp/qbsp.cc
@@ -1536,7 +1536,7 @@ static void LoadTextureData()
                 miptex.height = tex->meta.height;
 
                 // only mips can be embedded directly
-                if (!pos.archive->external && tex->meta.extension == img::ext::MIP) {
+                if (!qbsp_options.notextures.value() && !pos.archive->external && tex->meta.extension == img::ext::MIP) {
                     miptex.data = std::move(file.value());
                     continue;
                 }


### PR DESCRIPTION
The notex option appears to do nothing. I added this conditional and it seems to work for me. I would be curious to know how lack of textures affects the lighting stage because I've noticed no differences in the lightmap.