### PR TITLE
Use std::abs instead of abs() from C standard library

### DIFF
--- a/include/common/polylib.hh
+++ b/include/common/polylib.hh
@@ -1239,8 +1239,8 @@ public:
     {
         double worldextent = 0;
         for (int i = 0; i < 3; ++i) {
-            worldextent = max(worldextent, abs(bbox.maxs()[i]));
-            worldextent = max(worldextent, abs(bbox.mins()[i]));
+            worldextent = std::max(worldextent, std::abs(bbox.maxs()[i]));
+            worldextent = std::max(worldextent, std::abs(bbox.mins()[i]));
         }
         worldextent += 1;
 


### PR DESCRIPTION
abs() from C standard library operates on integers, which is almost certainly not what was intended here. The `double` and `float` versions are `fabs()` and `fabsf()` respectively. `std::abs()` is the overloaded version from the C++ library.

For some reason, building only fails on arm64 for me, not on amd64 (both Debian 12).