### PR TITLE
Support for building with MinGW-w64

### DIFF
--- a/common/cmdlib.cc
+++ b/common/cmdlib.cc
@@ -707,8 +707,8 @@ bool need_swap(std::ios_base &os)
 
 void *q_aligned_malloc(size_t align, size_t size)
 {
-#ifdef _mm_malloc
-    return _mm_malloc(size, align);
+#ifdef _WIN32
+    return _aligned_malloc(size, align);
 #elif __STDC_VERSION__ >= 201112L
     return aligned_alloc(align, size);
 #else
@@ -722,8 +722,8 @@ void *q_aligned_malloc(size_t align, size_t size)
 
 void q_aligned_free(void *ptr)
 {
-#ifdef _mm_malloc
-    _mm_free(ptr);
+#ifdef _WIN32
+    _aligned_free(ptr);
 #else
     free(ptr);
 #endif

--- a/common/threads.cc
+++ b/common/threads.cc
@@ -6,7 +6,7 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 static std::unique_ptr<tbb::global_control> tbbGlobalControl;

--- a/include/common/cmdlib.hh
+++ b/include/common/cmdlib.hh
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <cstring> // for memcpy()
 #include <string>
 #include <string_view>

--- a/include/common/mathlib.hh
+++ b/include/common/mathlib.hh
@@ -21,6 +21,7 @@
 
 #include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <vector>
 #include <algorithm>
 


### PR DESCRIPTION
MSYS2 now has MinGW packages available for [Embree](https://packages.msys2.org/base/mingw-w64-embree3) and [TBB](https://packages.msys2.org/base/mingw-w64-tbb). With the enclosed fixes, the project can be built natively with MSYS2 or cross-compiled from Linux.

Building with MSYS2 (using the MINGW64 shell):
```
$ pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-embree3 mingw-w64-x86_64-tbb
$ mkdir build
$ cd build
$ cmake .. -DCMAKE_BUILD_TYPE=Release -G"Unix Makefiles"
$ make
```

Cross-compiling from Debian:
```
$ apt install build-essential cmake mingw-w64  # i probably forgot some
$ mkdir ~/mingw
$ cd ~/mingw
$ wget https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-embree3-3.13.5-2-any.pkg.tar.zst \
       https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-tbb-2021.10.0-1-any.pkg.tar.zst \
       https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-hwloc-2.9.2-1-any.pkg.tar.zst \
       https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-libltdl-2.4.7-2-any.pkg.tar.zst
$ for f in *.zst; do bsdtar xf "$f"; done
$ cd -
$ mkdir build
$ cd build
$ cmake .. -DCMAKE_SYSTEM_NAME=Windows \
           -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc-posix \
           -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++-posix \
           -DCMAKE_FIND_ROOT_PATH="~/mingw/mingw64/" \
           -DCMAKE_BUILD_TYPE=Release
$ make
```

There are still (at least) a couple of issues: one is that libstdc++ is dynamic linked but the DLL isn't automatically copied alongside the binaries, and another is that tests.exe is useless when cross-compiled because the test map paths are hardcoded into the binary.


