### PR TITLE
qbsp: calculate bounds after transforming external map brush

### DIFF
--- a/qbsp/map.cc
+++ b/qbsp/map.cc
@@ -2942,6 +2942,8 @@ void ProcessExternalMapEntity(mapentity_t &entity)
             RotateMapFace(face, angles);
             TranslateMapFace(face, origin);
         }
+
+        CalculateBrushBounds(brush);
     }
 
     entity.epairs.set("classname", new_classname);


### PR DESCRIPTION
Fixes https://github.com/ericwa/ericw-tools/issues/372

The AABBs for the brushes were never (re)calculated after they had been transformed. This resulted in bad data being written to the BSP (usually an infinitely-sized AABB), making it impossible to get the axial planes of a brush.