### PR TITLE
lightpreview: Frustum culling and cull freeze.

### DIFF
--- a/lightpreview/glview.cpp
+++ b/lightpreview/glview.cpp
@@ -429,12 +429,6 @@ void GLView::updateFaceVisibility(const std::array<QVector4D, 4>& frustum)
 
     const face_visibility_key_t desired = desiredFaceVisibility();
 
-    if (m_uploaded_face_visibility &&
-        *m_uploaded_face_visibility == desired) {
-        //qDebug() << "reusing last frame visdata";
-        //return;
-    }
-
     qDebug() << "looking up pvs for clusternum " << desired.clusternum;
 
     const int face_visibility_width = m_bsp->dfaces.size();
@@ -490,8 +484,6 @@ void GLView::updateFaceVisibility(const std::array<QVector4D, 4>& frustum)
     }
 
     setFaceVisibilityArray(face_flags.data());
-
-    m_uploaded_face_visibility = desired;
 }
 
 bool GLView::shouldLiveUpdate() const
@@ -1036,7 +1028,6 @@ void GLView::setDrawTranslucencyAsOpaque(bool drawopaque)
 void GLView::setShowBmodels(bool bmodels)
 {
     // force re-upload of face visibility
-    m_uploaded_face_visibility = std::nullopt;
     m_showBmodels = bmodels;
     update();
 }
@@ -1179,7 +1170,6 @@ void GLView::renderBSP(const QString &file, const mbsp_t &bsp, const bspxentries
 
     num_leak_points = 0;
     num_portal_indices = 0;
-    m_uploaded_face_visibility = std::nullopt;
 
     int32_t highest_depth = 0;
 

--- a/lightpreview/glview.h
+++ b/lightpreview/glview.h
@@ -92,6 +92,9 @@ private:
     float m_displayAspect;
     QVector3D m_cameraOrigin;
     QVector3D m_cameraFwd; // unit vec
+    QVector3D m_cullOrigin;
+    QMatrix4x4 m_cullViewMatrix;
+    QMatrix4x4 m_cullModelMatrix;
     QVector3D cameraRight() const
     {
         QVector3D v = QVector3D::crossProduct(m_cameraFwd, QVector3D(0, 0, 1));
@@ -108,6 +111,8 @@ private:
     bool m_showTrisSeeThrough = false;
     bool m_drawFlat = false;
     bool m_keepOrigin = false;
+    bool m_keepCullFrustum = true;
+    bool m_keepCullOrigin = false;
     bool m_drawPortals = false;
     bool m_drawLeak = false;
     QOpenGLTexture::Filter m_filter = QOpenGLTexture::Linear;
@@ -124,6 +129,11 @@ private:
     QOpenGLVertexArrayObject m_portalVao;
     QOpenGLBuffer m_portalVbo;
     QOpenGLBuffer m_portalIndexBuffer;
+
+    QOpenGLVertexArrayObject m_frustumVao;
+    QOpenGLBuffer m_frustumVbo;
+    QOpenGLBuffer m_frustumFacesIndexBuffer;
+    QOpenGLBuffer m_frustumEdgesIndexBuffer;
 
     struct leaf_vao_t {
         QOpenGLVertexArrayObject vao;
@@ -212,6 +222,9 @@ public:
 
 private:
     void setFaceVisibilityArray(uint8_t *data);
+    static bool isVolumeInFrustum(const std::array<QVector4D, 4>& frustum, const qvec3f& mins, const qvec3f& maxs);
+    static std::vector<QVector3D> getFrustumCorners(float displayAspect);
+    static std::array<QVector4D, 4> getFrustumPlanes(const QMatrix4x4& MVP);
 
 public:
     void renderBSP(const QString &file, const mbsp_t &bsp, const bspxentries_t &bspx,
@@ -228,6 +241,8 @@ public:
     void setVisCulling(bool viscull);
     void setDrawFlat(bool drawflat);
     void setKeepOrigin(bool keeporigin);
+    void setKeepCullFrustum(bool keepfrustum);
+    void setKeepCullOrigin(bool keeporigin);
     void setDrawPortals(bool drawportals);
     void setDrawLeak(bool drawleak);
     // intensity = 0 to 200
@@ -245,7 +260,8 @@ protected:
     void resizeGL(int width, int height) override;
 
 private:
-    void updateFaceVisibility();
+    void updateFrustumVBO();
+    void updateFaceVisibility(const std::array<QVector4D, 4>& frustum);
     bool shouldLiveUpdate() const;
     void handleLoggedMessage(const QOpenGLDebugMessage &debugMessage);
 

--- a/lightpreview/glview.h
+++ b/lightpreview/glview.h
@@ -85,7 +85,6 @@ private:
     };
     face_visibility_key_t desiredFaceVisibility() const;
 
-    std::optional<face_visibility_key_t> m_uploaded_face_visibility;
     bool m_visCulling = true;
 
     // camera stuff

--- a/lightpreview/mainwindow.cpp
+++ b/lightpreview/mainwindow.cpp
@@ -205,6 +205,8 @@ void MainWindow::createPropertiesSidebar()
     visculling->setChecked(true);
 
     auto *keepposition = new QCheckBox(tr("Keep Camera Pos"));
+    auto *keepcullfrustum = new QCheckBox(tr("Keep Cull Frustum"));
+    auto *keepcullposition = new QCheckBox(tr("Keep Cull Pos"));
 
     nearest = new QCheckBox(tr("Nearest Filter"));
 
@@ -229,6 +231,8 @@ void MainWindow::createPropertiesSidebar()
     formLayout->addRow(showtris);
     formLayout->addRow(showtris_seethrough);
     formLayout->addRow(visculling);
+    formLayout->addRow(keepcullposition);
+    formLayout->addRow(keepcullfrustum);
     formLayout->addRow(keepposition);
     formLayout->addRow(nearest);
     formLayout->addRow(bspx_decoupled_lm);
@@ -266,6 +270,9 @@ void MainWindow::createPropertiesSidebar()
     common_options->setText(s.value("common_options").toString());
     qbsp_options->setText(s.value("qbsp_options").toString());
     vis_checkbox->setChecked(s.value("vis_enabled").toBool());
+    keepcullposition->setEnabled(vis_checkbox->isChecked());
+    keepcullfrustum->setEnabled(keepcullposition->isChecked());
+    keepcullfrustum->setChecked(true);
     vis_options->setText(s.value("vis_options").toString());
     light_options->setText(s.value("light_options").toString());
     nearest->setChecked(s.value("nearest").toBool());
@@ -282,7 +289,16 @@ void MainWindow::createPropertiesSidebar()
     connect(showtris, &QAbstractButton::toggled, this, [=](bool checked) { glView->setShowTris(checked); });
     connect(showtris_seethrough, &QAbstractButton::toggled, this,
         [=](bool checked) { glView->setShowTrisSeeThrough(checked); });
-    connect(visculling, &QAbstractButton::toggled, this, [=](bool checked) { glView->setVisCulling(checked); });
+    connect(visculling, &QAbstractButton::toggled, this, [=](bool checked) {
+        glView->setVisCulling(checked);
+        keepcullposition->setEnabled(checked);
+        keepcullfrustum->setEnabled(keepcullposition->isEnabled());
+    });
+    connect(keepcullposition, &QAbstractButton::toggled, this, [=](bool checked) {
+        glView->setKeepCullOrigin(checked);
+        keepcullfrustum->setEnabled(checked);
+    });
+    connect(keepcullfrustum, &QAbstractButton::toggled, this, [=](bool checked) { glView->setKeepCullFrustum(checked); });
     connect(drawflat, &QAbstractButton::toggled, this, [=](bool checked) { glView->setDrawFlat(checked); });
     connect(hull0, &QAbstractButton::toggled, this, [=](bool checked) { glView->setDrawLeafs(checked ? std::optional<int>{0} : std::nullopt); });
     connect(hull1, &QAbstractButton::toggled, this, [=](bool checked) { glView->setDrawLeafs(checked ? std::optional<int>{1} : std::nullopt); });


### PR DESCRIPTION
Adds frustum culling and the ability to freeze cull position to be able to visualize the impact the current vis data has on what's being rendered in common engine implementations. This is one piece of the puzzle when designing maps where performance is scrutinized by the players.