### PR TITLE
Have notriggermodels output the bounds of the point hull

### DIFF
--- a/qbsp/qbsp.cc
+++ b/qbsp/qbsp.cc
@@ -1094,8 +1094,10 @@ static void ProcessEntity(mapentity_t &entity, hull_index_t hullnum)
 
     // we're discarding the brush
     if (discarded_trigger) {
-        entity.epairs.set("mins", fmt::to_string(entity.bounds.mins()));
-        entity.epairs.set("maxs", fmt::to_string(entity.bounds.maxs()));
+        if (!hullnum.value_or(0)) {
+            entity.epairs.set("mins", fmt::to_string(entity.bounds.mins()));
+            entity.epairs.set("maxs", fmt::to_string(entity.bounds.maxs()));
+        }
         return;
     }
 


### PR DESCRIPTION
Currently notriggermodels outputs the mins/maxs of hull 2. It seems like the values are being overwritten for each hull, so it ends up writing the bounds of the last one.