### PR TITLE
Replace deprecated json submodule with new proper method

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "lib/fmt"]
 	path = 3rdparty/fmt
 	url = https://github.com/fmtlib/fmt
-[submodule "3rdparty/json"]
-	path = 3rdparty/json
-	url = https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
 [submodule "3rdparty/nanobench"]
 	path = 3rdparty/nanobench
 	url = https://github.com/martinus/nanobench

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory(fmt EXCLUDE_FROM_ALL)
-add_subdirectory(json EXCLUDE_FROM_ALL)
 add_subdirectory(nanobench EXCLUDE_FROM_ALL)
 
 set(BUILD_WITH_PEDANTIC_WARNINGS OFF CACHE BOOL "prevent pareto from adding /WX" FORCE)
@@ -15,3 +14,12 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(INSTALL_GTEST FALSE CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+
+FetchContent_Declare(
+        json
+        URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+        EXCLUDE_FROM_ALL
+        DOWNLOAD_EXTRACT_TIMESTAMP FALSE
+)
+
+FetchContent_MakeAvailable(json)


### PR DESCRIPTION
fixes error when configuring ericw-tools as a FetchContent module