### PR TITLE
Migrate to Qt6

### DIFF
--- a/.github/workflows/continuous-building.yml
+++ b/.github/workflows/continuous-building.yml
@@ -68,7 +68,10 @@ jobs:
       if: ${{ startsWith(matrix.os, 'macos-') }}
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.7.0
+        # 6.4.3 is the latest version supporting macOS 10.15
+        # see: https://doc.qt.io/archives/qt-6.4/macos.html
+        # and: https://wiki.qt.io/Qt_6.4_Release
+        version: 6.4.3
     - name: 'macOS: Build the artifact'
       if: startsWith(matrix.os, 'macos-')
       run: ./build-osx.sh

--- a/.github/workflows/continuous-building.yml
+++ b/.github/workflows/continuous-building.yml
@@ -33,7 +33,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
         sudo apt update
-        sudo apt install qt6-base
+        sudo apt install qt6-base-dev
     - name: 'Linux: Install TBB and Embree, if using distro packages'
       if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: |

--- a/.github/workflows/continuous-building.yml
+++ b/.github/workflows/continuous-building.yml
@@ -31,8 +31,8 @@ jobs:
 
     - name: Install Qt6
       uses: jurplel/install-qt-action@v4
-        with:
-          version: 6.7.0
+      with:
+        version: 6.7.0
 
     - name: 'Linux: Install TBB and Embree, if using distro packages'
       if: ${{ matrix.os == 'ubuntu-24.04' }}

--- a/.github/workflows/continuous-building.yml
+++ b/.github/workflows/continuous-building.yml
@@ -29,11 +29,11 @@ jobs:
       with:
         submodules: recursive
 
-    - name: 'Linux: Install Qt5'
-      if: startsWith(matrix.os, 'ubuntu-')
-      run: |
-        sudo apt update
-        sudo apt install qtbase5-dev libqt5svg5-dev
+    - name: Install Qt6
+      uses: jurplel/install-qt-action@v4
+        with:
+          version: 6.7.0
+
     - name: 'Linux: Install TBB and Embree, if using distro packages'
       if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: |
@@ -64,11 +64,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: 'macOS: Install Qt5'
-      if: ${{ startsWith(matrix.os, 'macos-') }}
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: 5.15.2
     - name: 'macOS: Build the artifact'
       if: startsWith(matrix.os, 'macos-')
       run: ./build-osx.sh
@@ -97,12 +92,6 @@ jobs:
     - name: 'Windows: Setup MSVC environment'
       if: startsWith(matrix.os, 'windows-')
       uses: ilammy/msvc-dev-cmd@v1
-    - name: 'Windows: Install Qt5'
-      if: ${{ startsWith(matrix.os, 'windows-') }}
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: 5.15.2
-        arch: win64_msvc2019_64
     - name: 'Windows: Build the artifact'
       if: startsWith(matrix.os, 'windows-')
       run: .\build-windows.ps1

--- a/.github/workflows/continuous-building.yml
+++ b/.github/workflows/continuous-building.yml
@@ -29,11 +29,11 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Qt6
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: 6.7.0
-
+    - name: 'Linux: Install Qt6'
+      if: startsWith(matrix.os, 'ubuntu-')
+      run: |
+        sudo apt update
+        sudo apt install qt6-base
     - name: 'Linux: Install TBB and Embree, if using distro packages'
       if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: |
@@ -64,6 +64,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: 'macOS: Install Qt6'
+      if: ${{ startsWith(matrix.os, 'macos-') }}
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.7.0
     - name: 'macOS: Build the artifact'
       if: startsWith(matrix.os, 'macos-')
       run: ./build-osx.sh
@@ -92,6 +97,11 @@ jobs:
     - name: 'Windows: Setup MSVC environment'
       if: startsWith(matrix.os, 'windows-')
       uses: ilammy/msvc-dev-cmd@v1
+    - name: 'Windows: Install Qt6'
+      if: ${{ startsWith(matrix.os, 'windows-') }}
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.7.0
     - name: 'Windows: Build the artifact'
       if: startsWith(matrix.os, 'windows-')
       run: .\build-windows.ps1

--- a/.github/workflows/continuous-building.yml
+++ b/.github/workflows/continuous-building.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install qt6-base-dev
+        sudo apt install libgl1-mesa-dev
     - name: 'Linux: Install TBB and Embree, if using distro packages'
       if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: |

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -20,7 +20,7 @@ choco install ninja
 mkdir build-windows
 cd build-windows
 
-cmake .. -GNinja -Dembree_DIR="C:\embree-4.4.0\lib\cmake\embree-4.4.0" -DTBB_DIR="C:\oneapi-tbb-2021.11.0\lib\cmake\tbb" -DCMAKE_BUILD_TYPE=Release -DENABLE_LIGHTPREVIEW=YES -DQt5Widgets_DIR="C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5Widgets"
+cmake .. -GNinja -Dembree_DIR="C:\embree-4.4.0\lib\cmake\embree-4.4.0" -DTBB_DIR="C:\oneapi-tbb-2021.11.0\lib\cmake\tbb" -DCMAKE_BUILD_TYPE=Release -DENABLE_LIGHTPREVIEW=YES -DQt6Widgets_DIR="C:\Qt\6.7.0\msvc2019_64\lib\cmake\Qt6Widgets"
 
 ninja package
 if ( $? -eq $false ) {

--- a/common/cmdlib.cc
+++ b/common/cmdlib.cc
@@ -692,7 +692,7 @@ bool string_icontains(std::string_view haystack, std::string_view needle)
     return string_ifind(haystack, needle) != haystack.end();
 }
 
-time_point I_FloatTime()
+qtime_point I_FloatTime()
 {
     return qclock::now();
 }

--- a/common/log.cc
+++ b/common/log.cc
@@ -179,14 +179,14 @@ void vprint(fmt::string_view format, fmt::format_args args)
     vprint(flag::DEFAULT, format, args);
 }
 
-static time_point start_time;
+static qtime_point start_time;
 static bool is_timing = false;
 static uint64_t last_count = -1;
-static time_point last_indeterminate_time;
+static qtime_point last_indeterminate_time;
 static std::atomic_bool locked = false;
 static std::array<duration, 10> one_percent_times;
 static size_t num_percent_times, percent_time_index;
-static time_point last_percent_time;
+static qtime_point last_percent_time;
 
 static duration average_times_for_one_percent()
 {

--- a/include/common/cmdlib.hh
+++ b/include/common/cmdlib.hh
@@ -103,9 +103,9 @@ bool string_icontains(std::string_view haystack, std::string_view needle);
 
 using qclock = std::chrono::high_resolution_clock;
 using duration = std::chrono::duration<double>;
-using time_point = std::chrono::time_point<qclock, duration>;
+using qtime_point = std::chrono::time_point<qclock, duration>;
 
-time_point I_FloatTime();
+qtime_point I_FloatTime();
 
 /*
  * ============================================================================

--- a/include/vis/vis.hh
+++ b/include/vis/vis.hh
@@ -248,7 +248,7 @@ void CalcAmbientSounds(mbsp_t *bsp);
 
 void CalcPHS(mbsp_t *bsp);
 
-extern time_point starttime, endtime, statetime;
+extern qtime_point starttime, endtime, statetime;
 
 void SaveVisState();
 bool LoadVisState();

--- a/lightpreview/CMakeLists.txt
+++ b/lightpreview/CMakeLists.txt
@@ -81,10 +81,12 @@ add_loader_path_to_rpath(lightpreview)
 
 # Install Qt DLL's
 if (WIN32)
+    install(FILES $<TARGET_FILE:Qt6::Core> DESTINATION .)
     install(FILES $<TARGET_FILE:Qt6::Widgets> DESTINATION .)
     install(FILES $<TARGET_FILE:Qt6::Gui> DESTINATION .)
-    install(FILES $<TARGET_FILE:Qt6::Core> DESTINATION .)
-    install(FILES "$<TARGET_FILE:Qt6::QWindowsIntegrationPlugin>" DESTINATION platforms)
+    install(FILES $<TARGET_FILE:Qt6::OpenGL> DESTINATION .)
+    install(FILES $<TARGET_FILE:Qt6::OpenGLWidgets> DESTINATION .)
+    install(FILES "$<TARGET_FILE:Qt6::QWindowsIntegrationPlugin>" DESTINATION plugins/platforms)
 endif ()
 
 function(apple_install_lib SRC_TARGET_NAME DEST_PATH)

--- a/lightpreview/CMakeLists.txt
+++ b/lightpreview/CMakeLists.txt
@@ -3,14 +3,16 @@ project (lightpreview CXX)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6Widgets)
-if(Qt6Widgets_FOUND)
+find_package(Qt6 COMPONENTS OpenGL Widgets OpenGLWidgets)
+if(Qt6_FOUND)
 else()
     message(WARNING "Qt6 not found, disabling lightpreview")
     return()
 endif()
 
-add_executable(lightpreview
+qt_standard_project_setup()
+
+qt_add_executable(lightpreview
     main.cpp
     mainwindow.cpp
     mainwindow.h
@@ -34,7 +36,12 @@ if (NOT EMBREE_TBB_DLL STREQUAL EMBREE_TBB_DLL-NOTFOUND)
 endif()
 
 target_link_libraries(lightpreview
+        PRIVATE
+        Qt6::Core
         Qt6::Widgets
+        Qt6::Gui
+        Qt6::OpenGL
+        Qt6::OpenGLWidgets
         libqbsp
         liblight
         libvis
@@ -48,9 +55,13 @@ target_link_libraries(lightpreview
 if (WIN32)
     add_custom_command(
         TARGET lightpreview POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt6::Widgets> $<TARGET_FILE_DIR:lightpreview>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt6::Gui> $<TARGET_FILE_DIR:lightpreview>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt6::Core> $<TARGET_FILE_DIR:lightpreview>
+        COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:Qt6::Core> $<TARGET_FILE_DIR:lightpreview>/$<TARGET_FILE_NAME:Qt6::Core>
+        COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:Qt6::Widgets> $<TARGET_FILE_DIR:lightpreview>/$<TARGET_FILE_NAME:Qt6::Widgets>
+        COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:Qt6::Gui> $<TARGET_FILE_DIR:lightpreview>/$<TARGET_FILE_NAME:Qt6::Gui>
+        COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:Qt6::OpenGL> $<TARGET_FILE_DIR:lightpreview>/$<TARGET_FILE_NAME:Qt6::OpenGL>
+        COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:Qt6::OpenGLWidgets> $<TARGET_FILE_DIR:lightpreview>/$<TARGET_FILE_NAME:Qt6::OpenGLWidgets>
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:lightpreview>/plugins/platforms
+        COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:Qt6::QWindowsIntegrationPlugin> $<TARGET_FILE_DIR:lightpreview>/plugins/platforms/$<TARGET_FILE_NAME:Qt6::QWindowsIntegrationPlugin>
     )
 
     # HACK: copy .dll dependencies

--- a/lightpreview/CMakeLists.txt
+++ b/lightpreview/CMakeLists.txt
@@ -112,16 +112,18 @@ if (APPLE)
     apple_install_lib(embree "$<TARGET_FILE_DIR:lightpreview>")
 
     # TODO: this should be replaced with macdeployqt
-    apple_install_lib(Qt6::Widgets "$<TARGET_FILE_DIR:lightpreview>/QtWidgets.framework/Versions/5")
-    apple_install_lib(Qt6::Gui "$<TARGET_FILE_DIR:lightpreview>/QtGui.framework/Versions/5")
-    apple_install_lib(Qt6::Core "$<TARGET_FILE_DIR:lightpreview>/QtCore.framework/Versions/5")
+    apple_install_lib(Qt6::Core "$<TARGET_FILE_DIR:lightpreview>/QtCore.framework/Versions/6")
+    apple_install_lib(Qt6::Widgets "$<TARGET_FILE_DIR:lightpreview>/QtWidgets.framework/Versions/6")
+    apple_install_lib(Qt6::Gui "$<TARGET_FILE_DIR:lightpreview>/QtGui.framework/Versions/6")
+    apple_install_lib(Qt6::OpenGL "$<TARGET_FILE_DIR:lightpreview>/QtOpenGL.framework/Versions/6")
+    apple_install_lib(Qt6::OpenGLWidgets "$<TARGET_FILE_DIR:lightpreview>/QtOpenGLWidgets.framework/Versions/6")
     apple_install_lib(Qt6::QCocoaIntegrationPlugin "$<TARGET_FILE_DIR:lightpreview>/platforms")
 
     # these are required by QCocoaIntegrationPlugin
     find_package(Qt6DBus REQUIRED)
     find_package(Qt6PrintSupport REQUIRED)
-    apple_install_lib(Qt6::PrintSupport "$<TARGET_FILE_DIR:lightpreview>/QtPrintSupport.framework/Versions/5")
-    apple_install_lib(Qt6::DBus "$<TARGET_FILE_DIR:lightpreview>/QtDBus.framework/Versions/5")
+    apple_install_lib(Qt6::PrintSupport "$<TARGET_FILE_DIR:lightpreview>/QtPrintSupport.framework/Versions/6")
+    apple_install_lib(Qt6::DBus "$<TARGET_FILE_DIR:lightpreview>/QtDBus.framework/Versions/6")
 endif ()
 
 install(TARGETS lightpreview RUNTIME DESTINATION . BUNDLE DESTINATION .)

--- a/lightpreview/CMakeLists.txt
+++ b/lightpreview/CMakeLists.txt
@@ -112,18 +112,18 @@ if (APPLE)
     apple_install_lib(embree "$<TARGET_FILE_DIR:lightpreview>")
 
     # TODO: this should be replaced with macdeployqt
-    apple_install_lib(Qt6::Core "$<TARGET_FILE_DIR:lightpreview>/QtCore.framework/Versions/6")
-    apple_install_lib(Qt6::Widgets "$<TARGET_FILE_DIR:lightpreview>/QtWidgets.framework/Versions/6")
-    apple_install_lib(Qt6::Gui "$<TARGET_FILE_DIR:lightpreview>/QtGui.framework/Versions/6")
-    apple_install_lib(Qt6::OpenGL "$<TARGET_FILE_DIR:lightpreview>/QtOpenGL.framework/Versions/6")
-    apple_install_lib(Qt6::OpenGLWidgets "$<TARGET_FILE_DIR:lightpreview>/QtOpenGLWidgets.framework/Versions/6")
+    apple_install_lib(Qt6::Core "$<TARGET_FILE_DIR:lightpreview>/QtCore.framework/Versions/A")
+    apple_install_lib(Qt6::Widgets "$<TARGET_FILE_DIR:lightpreview>/QtWidgets.framework/Versions/A")
+    apple_install_lib(Qt6::Gui "$<TARGET_FILE_DIR:lightpreview>/QtGui.framework/Versions/A")
+    apple_install_lib(Qt6::OpenGL "$<TARGET_FILE_DIR:lightpreview>/QtOpenGL.framework/Versions/A")
+    apple_install_lib(Qt6::OpenGLWidgets "$<TARGET_FILE_DIR:lightpreview>/QtOpenGLWidgets.framework/Versions/A")
     apple_install_lib(Qt6::QCocoaIntegrationPlugin "$<TARGET_FILE_DIR:lightpreview>/platforms")
 
     # these are required by QCocoaIntegrationPlugin
     find_package(Qt6DBus REQUIRED)
     find_package(Qt6PrintSupport REQUIRED)
-    apple_install_lib(Qt6::PrintSupport "$<TARGET_FILE_DIR:lightpreview>/QtPrintSupport.framework/Versions/6")
-    apple_install_lib(Qt6::DBus "$<TARGET_FILE_DIR:lightpreview>/QtDBus.framework/Versions/6")
+    apple_install_lib(Qt6::PrintSupport "$<TARGET_FILE_DIR:lightpreview>/QtPrintSupport.framework/Versions/A")
+    apple_install_lib(Qt6::DBus "$<TARGET_FILE_DIR:lightpreview>/QtDBus.framework/Versions/A")
 endif ()
 
 install(TARGETS lightpreview RUNTIME DESTINATION . BUNDLE DESTINATION .)

--- a/lightpreview/CMakeLists.txt
+++ b/lightpreview/CMakeLists.txt
@@ -3,10 +3,10 @@ project (lightpreview CXX)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5Widgets)
-if(Qt5Widgets_FOUND)
+find_package(Qt6Widgets)
+if(Qt6Widgets_FOUND)
 else()
-    message(WARNING "Qt5 not found, disabling lightpreview")
+    message(WARNING "Qt6 not found, disabling lightpreview")
     return()
 endif()
 
@@ -34,7 +34,7 @@ if (NOT EMBREE_TBB_DLL STREQUAL EMBREE_TBB_DLL-NOTFOUND)
 endif()
 
 target_link_libraries(lightpreview
-        Qt5::Widgets
+        Qt6::Widgets
         libqbsp
         liblight
         libvis
@@ -48,9 +48,9 @@ target_link_libraries(lightpreview
 if (WIN32)
     add_custom_command(
         TARGET lightpreview POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::Widgets> $<TARGET_FILE_DIR:lightpreview>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::Gui> $<TARGET_FILE_DIR:lightpreview>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt5::Core> $<TARGET_FILE_DIR:lightpreview>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt6::Widgets> $<TARGET_FILE_DIR:lightpreview>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt6::Gui> $<TARGET_FILE_DIR:lightpreview>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Qt6::Core> $<TARGET_FILE_DIR:lightpreview>
     )
 
     # HACK: copy .dll dependencies
@@ -70,14 +70,14 @@ add_loader_path_to_rpath(lightpreview)
 
 # Install Qt DLL's
 if (WIN32)
-    install(FILES $<TARGET_FILE:Qt5::Widgets> DESTINATION .)
-    install(FILES $<TARGET_FILE:Qt5::Gui> DESTINATION .)
-    install(FILES $<TARGET_FILE:Qt5::Core> DESTINATION .)
-    install(FILES "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" DESTINATION platforms)
+    install(FILES $<TARGET_FILE:Qt6::Widgets> DESTINATION .)
+    install(FILES $<TARGET_FILE:Qt6::Gui> DESTINATION .)
+    install(FILES $<TARGET_FILE:Qt6::Core> DESTINATION .)
+    install(FILES "$<TARGET_FILE:Qt6::QWindowsIntegrationPlugin>" DESTINATION platforms)
 endif ()
 
 function(apple_install_lib SRC_TARGET_NAME DEST_PATH)
-    # SRC_TARGET_NAME - a target name, e.g. Qt5::Widgets
+    # SRC_TARGET_NAME - a target name, e.g. Qt6::Widgets
     # DEST_PATH - destination path to install the library to
     
     get_target_property(SO_FILE_SYMLINK ${SRC_TARGET_NAME} IMPORTED_LOCATION_RELEASE)
@@ -99,16 +99,16 @@ if (APPLE)
     apple_install_lib(embree "$<TARGET_FILE_DIR:lightpreview>")
 
     # TODO: this should be replaced with macdeployqt
-    apple_install_lib(Qt5::Widgets "$<TARGET_FILE_DIR:lightpreview>/QtWidgets.framework/Versions/5")
-    apple_install_lib(Qt5::Gui "$<TARGET_FILE_DIR:lightpreview>/QtGui.framework/Versions/5")
-    apple_install_lib(Qt5::Core "$<TARGET_FILE_DIR:lightpreview>/QtCore.framework/Versions/5")
-    apple_install_lib(Qt5::QCocoaIntegrationPlugin "$<TARGET_FILE_DIR:lightpreview>/platforms")
+    apple_install_lib(Qt6::Widgets "$<TARGET_FILE_DIR:lightpreview>/QtWidgets.framework/Versions/5")
+    apple_install_lib(Qt6::Gui "$<TARGET_FILE_DIR:lightpreview>/QtGui.framework/Versions/5")
+    apple_install_lib(Qt6::Core "$<TARGET_FILE_DIR:lightpreview>/QtCore.framework/Versions/5")
+    apple_install_lib(Qt6::QCocoaIntegrationPlugin "$<TARGET_FILE_DIR:lightpreview>/platforms")
 
     # these are required by QCocoaIntegrationPlugin
-    find_package(Qt5DBus REQUIRED)
-    find_package(Qt5PrintSupport REQUIRED)
-    apple_install_lib(Qt5::PrintSupport "$<TARGET_FILE_DIR:lightpreview>/QtPrintSupport.framework/Versions/5")
-    apple_install_lib(Qt5::DBus "$<TARGET_FILE_DIR:lightpreview>/QtDBus.framework/Versions/5")
+    find_package(Qt6DBus REQUIRED)
+    find_package(Qt6PrintSupport REQUIRED)
+    apple_install_lib(Qt6::PrintSupport "$<TARGET_FILE_DIR:lightpreview>/QtPrintSupport.framework/Versions/5")
+    apple_install_lib(Qt6::DBus "$<TARGET_FILE_DIR:lightpreview>/QtDBus.framework/Versions/5")
 endif ()
 
 install(TARGETS lightpreview RUNTIME DESTINATION . BUNDLE DESTINATION .)

--- a/lightpreview/CMakeLists.txt
+++ b/lightpreview/CMakeLists.txt
@@ -10,7 +10,11 @@ else()
     return()
 endif()
 
-qt_standard_project_setup()
+message(STATUS "Using Qt version: ${Qt6_VERSION}")
+
+if ("${Qt6_VERSION}" VERSION_GREATER_EQUAL "6.3.0")
+    qt_standard_project_setup()
+endif()
 
 qt_add_executable(lightpreview
     main.cpp

--- a/lightpreview/glview.h
+++ b/lightpreview/glview.h
@@ -61,7 +61,7 @@ private:
     std::unordered_map<int, std::vector<uint8_t>> m_decompressedVis;
 
     uint32_t m_keysPressed;
-    std::optional<time_point> m_lastFrame;
+    std::optional<qtime_point> m_lastFrame;
     std::optional<QPoint> m_lastMouseDownPos;
     /**
      * units / second

--- a/lightpreview/main.cpp
+++ b/lightpreview/main.cpp
@@ -31,12 +31,8 @@ int main(int argc, char *argv[])
 
     QCoreApplication::setOrganizationName("ericw-tools");
     QCoreApplication::setApplicationName("lightpreview");
-
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     // allow non-integer monitor scaling
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-#endif
 
     QApplication a(argc, argv);
     a.setStyle("fusion");

--- a/lightpreview/mainwindow.h
+++ b/lightpreview/mainwindow.h
@@ -29,7 +29,6 @@ class GLView;
 class QFileSystemWatcher;
 class QLineEdit;
 class QCheckBox;
-class QStringList;
 class QTextEdit;
 class StatsPanel;
 class QLabel;

--- a/vis/vis.cc
+++ b/vis/vis.cc
@@ -353,7 +353,7 @@ static void PortalCompleted(visstats_t &stats, visportal_t *completed)
     portal_mutex.unlock();
 }
 
-time_point starttime, endtime, statetime;
+qtime_point starttime, endtime, statetime;
 static duration stateinterval;
 
 /*

--- a/vis/vis.cc
+++ b/vis/vis.cc
@@ -705,9 +705,9 @@ void vis_reset()
 
     portalIndex = 0;
 
-    starttime = time_point();
-    endtime = time_point();
-    statetime = time_point();
+    starttime = {};
+    endtime = {};
+    statetime = {};
 
     stateinterval = duration();
 


### PR DESCRIPTION
Completion of https://github.com/ericwa/ericw-tools/pull/445

TODO:

- [x] Test Windows artifact from GH Actions (locally `cpack`'ed .zip seems to work)
- [x] Ubuntu build should use distro's qt6, probably (that's what we currently do on qt5 on Linux iirc)
- [x] Test Linux artifact from GH Actions 
- [x] macOS artifact tested on macOS 10.15.7 (x86_64)