### PR TITLE
Smooth out Mac building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../vcpkg/scripts/buildsystems/vcpkg.cmak
 ### macOS 10.15+
 
 ```
-brew install embree tbb qt@6
+brew install embree tbb qt@6 cmake
 python3 -m pip install sphinx_rtd_theme
 git clone --recursive https://github.com/ericwa/ericw-tools
 cd ericw-tools


### PR DESCRIPTION
Hey there! I recently gave the Mac build instructions a go and ran into a couple hiccups which I thought I'd create a PR for.

The main one is it's a lot more straightforward to not use Xcode for building (`-GXcode`), as well as being explicit about running the `make` command at the end.

I also added `qt@6` as it looks like its required for `lightpreview` which is coming down the pipe. And I actually didn't have `cmake` installed yet so I added that too.

Also added `make` at the end of the Ubuntu instructions to be explicit.