### PR TITLE
Default ANSI color codes off when stdout is NOT a TTY

### DIFF
--- a/common/log.cc
+++ b/common/log.cc
@@ -36,19 +36,19 @@
 #include <common/cmdlib.hh>
 
 #if defined(_WIN32)
-#   define WIN32_LEAN_AND_MEAN
-#   include <windows.h> // for OutputDebugStringA
-#   include <io.h> // for _isatty
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h> // for OutputDebugStringA
+#include <io.h> // for _isatty
 
-#   ifdef min
-#       undef min
-#   endif
-#   ifdef max
-#       undef max
-#   endif
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
 
 #elif defined(__unix__)
-#   include <unistd.h> // for isatty
+#include <unistd.h> // for isatty
 #endif
 
 static std::ofstream logfile;
@@ -58,7 +58,8 @@ namespace logging
 bitflags<flag> mask = bitflags<flag>(flag::ALL) & ~bitflags<flag>(flag::VERBOSE);
 bool enable_color_codes = false;
 
-static bool is_terminal() {
+static bool is_terminal()
+{
 #if defined(_WIN32)
     return _isatty(_fileno(stdout)) != 0;
 #elif defined(__unix__)

--- a/common/log.cc
+++ b/common/log.cc
@@ -35,7 +35,7 @@
 #include <common/settings.hh>
 #include <common/cmdlib.hh>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h> // for OutputDebugStringA
 #include <io.h> // for _isatty
@@ -47,9 +47,9 @@
 #undef max
 #endif
 
-#elif defined(__unix__)
+#else // assume __unix__ is defined
 #include <unistd.h> // for isatty
-#endif
+#endif // ifdef _WIN32
 
 static std::ofstream logfile;
 
@@ -60,12 +60,10 @@ bool enable_color_codes = false;
 
 static bool is_terminal()
 {
-#if defined(_WIN32)
+#ifdef _WIN32
     return _isatty(_fileno(stdout)) != 0;
-#elif defined(__unix__)
-    return isatty(STDOUT_FILENO) != 0;
 #else
-    return true;
+    return isatty(STDOUT_FILENO) != 0;
 #endif
 }
 


### PR DESCRIPTION
Prevents ANSI color codes from being printed in output in e.g. TrenchBroom without the need for -nocolor switch.  Also prevents color codes from appearing when redirecting output, e.g. `qbsp my.map | cat`

Tested w/ TrenchBroom under Linux: No ANSI codes are printed
Tested w/ terminal under Linux (`qbsp some.map`): Output displayed w/ color
Tested w/ terminal under Linux/Wine (`wine qbsp.exe some.map`): ANSI color codes are printed
Tested w/ terminal under Linux/Wine w/ redirected output (`wine qbsp.exe some.map | cat`): No ANSI color codes are printed