### PR TITLE
Treat triggers as SKIP, and treat `aaa` prefix as trigger in HL1 mode

### DIFF
--- a/common/bspfile.cc
+++ b/common/bspfile.cc
@@ -195,7 +195,7 @@ public:
         const surfflags_t &flags, const char *texname, bool light_nodraw, bool lightgrid_enabled) const override
     {
         /* don't save lightmaps for "trigger" texture */
-        if (!Q_strcasecmp(texname, "trigger"))
+        if (string_istarts_with(texname, "trigger"))
             return false;
 
         /* don't save lightmaps for "skip" texture */
@@ -215,7 +215,7 @@ public:
     bool surf_is_emissive(const surfflags_t &flags, const char *texname) const override
     {
         /* don't save lightmaps for "trigger" texture */
-        if (!Q_strcasecmp(texname, "trigger"))
+        if (string_istarts_with(texname, "trigger"))
             return false;
         
         /* if in HL1 mode, don't save lightmaps for "aaa" prefix 

--- a/common/bspfile.cc
+++ b/common/bspfile.cc
@@ -201,6 +201,13 @@ public:
         /* don't save lightmaps for "skip" texture */
         if (!Q_strcasecmp(texname, "skip"))
             return false;
+        
+        /* if in HL1 mode, don't save lightmaps for "aaa" prefix 
+        base Half-Life only has "aaatrigger", but mods like Opposing Force and Condition Zero
+        add other trigger textures, such as "aaa_hurt" and "aaa_push"
+        */
+        if (allows_hl_contents && (string_istarts_with(texname, "aaa")) )
+            return false;
 
         return !(flags.native_q1 & TEX_SPECIAL);
     }
@@ -210,7 +217,14 @@ public:
         /* don't save lightmaps for "trigger" texture */
         if (!Q_strcasecmp(texname, "trigger"))
             return false;
-
+        
+        /* if in HL1 mode, don't save lightmaps for "aaa" prefix 
+        base Half-Life only has "aaatrigger", but mods like Opposing Force and Condition Zero
+        add other trigger textures, such as "aaa_hurt" and "aaa_push"
+        */
+        if (allows_hl_contents && (string_istarts_with(texname, "aaa")) )
+            return false;
+        
         return true;
     }
 

--- a/docs/qbsp.rst
+++ b/docs/qbsp.rst
@@ -321,10 +321,12 @@ Options
    For supported game code only: triggers will not write a model out,
    and will instead just write out their mins/maxs.
 
-.. option:: -nodrawtriggers
+.. option:: -keeptriggerfaces
 
-   Treat triggers as if they were textured with SKIP, reducing vertex count.
-   Unlike -notriggermodels, this does not require supported game code.
+   Keep trigger brush faces, in the compiled BSP. Normally they are
+   stripped, to reduce vertex count.
+   
+   No effect if `-notriggermodels` is used.
    
 .. option:: -notex
 

--- a/docs/qbsp.rst
+++ b/docs/qbsp.rst
@@ -321,6 +321,11 @@ Options
    For supported game code only: triggers will not write a model out,
    and will instead just write out their mins/maxs.
 
+.. option:: -nodrawtriggers
+
+   Treat triggers as if they were textured with SKIP, reducing vertex count.
+   Unlike -notriggermodels, this does not require supported game code.
+   
 .. option:: -notex
 
    Write only placeholder textures, to depend upon replacements. This

--- a/include/qbsp/qbsp.hh
+++ b/include/qbsp/qbsp.hh
@@ -221,7 +221,7 @@ public:
     setting_bool omitdetailfence;
     setting_wadpathset wadpaths;
     setting_bool notriggermodels;
-    setting_bool nodrawtriggers;
+    setting_bool keeptriggerfaces;
     setting_set aliasdefs;
     setting_set texturedefs;
     setting_numeric<double> lmscale;

--- a/include/qbsp/qbsp.hh
+++ b/include/qbsp/qbsp.hh
@@ -221,6 +221,7 @@ public:
     setting_bool omitdetailfence;
     setting_wadpathset wadpaths;
     setting_bool notriggermodels;
+    setting_bool nodrawtriggers;
     setting_set aliasdefs;
     setting_set texturedefs;
     setting_numeric<double> lmscale;

--- a/qbsp/map.cc
+++ b/qbsp/map.cc
@@ -513,6 +513,13 @@ static bool IsSkipName(const char *name)
         return true;
     if (!Q_strcasecmp(name, "null")) // zhlt compat
         return true;
+    if (nodrawtriggers)
+    {
+        if (!Q_strcasecmp(name, "trigger"))
+            return true;
+        if (game->allows_hl_contents && string_istarts_with(name, "aaa")) // aaatrigger, aaa_hurt, etc.
+            return true;
+    }
     return false;
 }
 

--- a/qbsp/map.cc
+++ b/qbsp/map.cc
@@ -513,7 +513,7 @@ static bool IsSkipName(const char *name)
         return true;
     if (!Q_strcasecmp(name, "null")) // zhlt compat
         return true;
-    if (nodrawtriggers)
+    if (qbsp_options.nodrawtriggers.value())
     {
         if (!Q_strcasecmp(name, "trigger"))
             return true;

--- a/qbsp/map.cc
+++ b/qbsp/map.cc
@@ -513,9 +513,9 @@ static bool IsSkipName(const char *name)
         return true;
     if (!Q_strcasecmp(name, "null")) // zhlt compat
         return true;
-    if (qbsp_options.nodrawtriggers.value())
+    if (!qbsp_options.keeptriggerfaces.value())
     {
-        if (!Q_strcasecmp(name, "trigger"))
+        if (string_istarts_with(name, "trigger"))
             return true;
         if (game->allows_hl_contents && string_istarts_with(name, "aaa")) // aaatrigger, aaa_hurt, etc.
             return true;

--- a/qbsp/qbsp.cc
+++ b/qbsp/qbsp.cc
@@ -544,8 +544,8 @@ qbsp_settings::qbsp_settings()
           "add a path to the wad search paths; wads found in xwadpath's will not be embedded, otherwise they will be embedded (if not -notex)"},
       notriggermodels{this, "notriggermodels", false, &common_format_group,
           "for supported game code only: triggers will not write a model\nout, and will instead just write out their mins/maxs."},
-      nodrawtriggers{this, "nodrawtriggers", false, &common_format_group,
-          "Treat triggers as if they were textured with SKIP, reducing vertex count. Unlike -notriggermodels, this does not require supported game code."},
+      keeptriggerfaces{this, "keeptriggerfaces", false, &common_format_group,
+          "Keep trigger brush faces, in the compiled BSP. Normally they are stripped, to reduce vertex count."},
       aliasdefs{this, "aliasdef", "\"path/to/file.def\" <multiple allowed>", &map_development_group,
           "path to an alias definition file, which can transform entities in the .map into other entities."},
       texturedefs{this, "texturedefs", "\"path/to/file.def\" <multiple allowed>", &map_development_group,
@@ -1030,7 +1030,7 @@ static void ProcessEntity(mapentity_t &entity, hull_index_t hullnum)
         return;
 
     // for notriggermodels: if we have at least one trigger-like texture, do special trigger stuff
-    bool discarded_trigger = !map.is_world_entity(entity) && qbsp_options.notriggermodels.value() && IsTrigger(entity);
+    bool discarded_trigger = !map.is_world_entity(entity) && !qbsp_options.keeptriggerfaces.value() && IsTrigger(entity);
 
     // Export a blank model struct, and reserve the index (only do this once, for all hulls)
     if (!discarded_trigger) {

--- a/qbsp/qbsp.cc
+++ b/qbsp/qbsp.cc
@@ -544,6 +544,8 @@ qbsp_settings::qbsp_settings()
           "add a path to the wad search paths; wads found in xwadpath's will not be embedded, otherwise they will be embedded (if not -notex)"},
       notriggermodels{this, "notriggermodels", false, &common_format_group,
           "for supported game code only: triggers will not write a model\nout, and will instead just write out their mins/maxs."},
+      nodrawtriggers{this, "nodrawtriggers", false, &common_format_group,
+          "Treat triggers as if they were textured with SKIP, reducing vertex count. Unlike -notriggermodels, this does not require supported game code."},
       aliasdefs{this, "aliasdef", "\"path/to/file.def\" <multiple allowed>", &map_development_group,
           "path to an alias definition file, which can transform entities in the .map into other entities."},
       texturedefs{this, "texturedefs", "\"path/to/file.def\" <multiple allowed>", &map_development_group,


### PR DESCRIPTION
Reimplements trigger-related portions of #386 in slightly more backward-compatible ways.

* Trigger textures now no longer emit faces, greatly reducing vertex count. This is important for vanilla BSP formats (BSP29, BSP30, BSP38).
* `trigger` now acts as a prefix, allowing custom trigger textures named things such as `trigger_hurt` or `trigger_tele`.
* `aaa` now acts as a prefix for triggers in HL1 mode. The default trigger texture in GoldSrc is `aaatrigger` (see halflife.wad), and some games have additional textures such as `aaa_hurt` or `aaa_push` (see opfor.wad).

<details>
<summary>Old Description</summary>
~~EWT applies TEX_SPECIAL for the `trigger` texture, unlike vanilla compilers. This saves lightmap usage (and speeds up compile times),~~ but it still counts towards vertex limits (particularly important for HL1, wherein vanilla BSP compatibility is expected, so BSP2 is a no-go). I've added a new QBSP arg, `-nodrawtriggers`, to treat triggers as if textured with SKIP.
This definitely works in HL1 (it's default behavior in VHLT), and I don't see why it wouldn't work in Q1. I didn't make it default behavior because leaving the trigger model can be useful for map debugging in mods/engines that have a cvar to render triggers (but having the behavior inverted could make sense). I considered calling it `-skiptriggers`, to go with the usual nomenclature, but I was concerned that would sound like it was removing trigger entities. Feel free to rename it to something like `-triggers_as_skip` if you think that would be more suitable (current arg name is taken from VBSP). 

The standard trigger texture in Half-Life is `AAATRIGGER`, however some games like Opposing Force and Condition Zero have addtional trigger textures for signifying different types of triggers, such as `aaa_hurt` for trigger_hurt and `aaa_push` for trigger_push. As such, I've treated `aaa` as a prefix for trigger textures, but only in HL1 mode (although if the ability to use multiple trigger textures for different trigger types is desired by Q1 mappers, this could be changed to be allowed with a QBSP arg).
</details>